### PR TITLE
[NPA-535] - Modify ReadByExtAttrs method to handle the case when the WAPI response returns an Empty List

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,7 +8,22 @@ terraform {
 }
 
 provider "nios" {
-    nios_host_url="<NIOS_HOST_URL>"
-    nios_username="<NIOS_USERNAME>"
-    nios_password="<NIOS_PASSWORD>"
+    nios_host_url="https://172.28.83.91"
+    nios_username="admin"
+    nios_password="Infoblox@123"
+}
+
+
+resource "nios_dns_record_a" "create_record" {
+  name     = "example_test71.example.com"
+  ipv4addr = "10.20.1.2"
+  view     = "default"
+  comment = ""
+}
+
+resource "nios_dns_record_a" "create_record1" {
+  name     = "example_test72.example.com"
+  ipv4addr = "10.20.1.2"
+  view     = "default"
+  comment = ""
 }

--- a/internal/service/dns/record_a_resource.go
+++ b/internal/service/dns/record_a_resource.go
@@ -235,8 +235,8 @@ func (r *RecordAResource) ReadByExtAttrs(ctx context.Context, data *RecordAModel
 	if diags.HasError() {
 		return true
 	}
-	data.Flatten(ctx, &res, &resp.Diagnostics)
 
+	data.Flatten(ctx, &res, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 
 	return true
@@ -323,9 +323,9 @@ func (r *RecordAResource) addInternalIDToExtAttrs(ctx context.Context, data *Rec
 	var internalId string
 	if !data.ExtAttrsAll.IsNull() {
 		elements := data.ExtAttrsAll.Elements()
-		if tid, ok := elements["Terraform Internal ID"]; ok {
-			if tidStr, ok := tid.(types.String); ok {
-				internalId = tidStr.ValueString()
+		if tId, ok := elements["Terraform Internal ID"]; ok {
+			if tIdStr, ok := tId.(types.String); ok {
+				internalId = tIdStr.ValueString()
 			}
 		}
 	}


### PR DESCRIPTION
Deletion of a RecordA via the UI leads to a state inconsistency between Terraform state and the backend, 
because the API returns an empty list with a 200 status code instead of an error when the record does not exist. 

This PR updates the `ReadByExtAttrs` method to handle cases where the API response is an empty list