### PR TITLE
[NPA-556] Added Expand function to Parse `types.Map` to `map[string]interface`

### DIFF
--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	internaltypes "github.com/infobloxopen/terraform-provider-nios/internal/types"
+	"github.com/infobloxopen/terraform-provider-nios/internal/utils"
 )
 
 type FrameworkElementFlExFunc[T any, U any] func(context.Context, T, *diag.Diagnostics) U
@@ -295,6 +296,27 @@ func ExpandFrameworkMapString(ctx context.Context, tfMap types.Map, diags *diag.
 	elementsNew := make(map[string]interface{}, len(tfMap.Elements()))
 	for k, v := range elements {
 		elementsNew[k] = v
+	}
+	return elementsNew
+}
+
+// ExpandParsedFrameworkMapString parses interface value and expands a Terraform map of strings into a map of interface{}.
+func ExpandParsedFrameworkMapString(ctx context.Context, tfMap types.Map, diags *diag.Diagnostics) map[string]interface{} {
+	if tfMap.IsNull() || tfMap.IsUnknown() {
+		return nil
+	}
+	var elements map[string]string
+	diags.Append(tfMap.ElementsAs(ctx, &elements, false)...)
+	if diags.HasError() {
+		return nil
+
+	}
+
+	elementsNew := make(map[string]interface{})
+
+	for key, valStr := range elements {
+		parsedValue := utils.ParseInterfaceValue(valStr)
+		elementsNew[key] = parsedValue
 	}
 	return elementsNew
 }

--- a/internal/service/dns/model_func_call.go
+++ b/internal/service/dns/model_func_call.go
@@ -80,7 +80,7 @@ func (m *FuncCallModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dn
 	to := &dns.FuncCall{
 		AttributeName:    flex.ExpandString(m.AttributeName),
 		ObjectFunction:   flex.ExpandStringPointer(m.ObjectFunction),
-		Parameters:       flex.ExpandFrameworkMapString(ctx, m.Parameters, diags),
+		Parameters:       flex.ExpandParsedFrameworkMapString(ctx, m.Parameters, diags),
 		ResultField:      flex.ExpandStringPointer(m.ResultField),
 		Object:           flex.ExpandStringPointer(m.Object),
 		ObjectParameters: flex.ExpandFrameworkMapString(ctx, m.ObjectParameters, diags),

--- a/internal/service/ipam/model_func_call.go
+++ b/internal/service/ipam/model_func_call.go
@@ -80,7 +80,7 @@ func (m *FuncCallModel) Expand(ctx context.Context, diags *diag.Diagnostics) *ip
 	to := &ipam.FuncCall{
 		AttributeName:    flex.ExpandString(m.AttributeName),
 		ObjectFunction:   flex.ExpandStringPointer(m.ObjectFunction),
-		Parameters:       flex.ExpandFrameworkMapString(ctx, m.Parameters, diags),
+		Parameters:       flex.ExpandParsedFrameworkMapString(ctx, m.Parameters, diags),
 		ResultField:      flex.ExpandStringPointer(m.ResultField),
 		Object:           flex.ExpandStringPointer(m.Object),
 		ObjectParameters: flex.ExpandFrameworkMapString(ctx, m.ObjectParameters, diags),


### PR DESCRIPTION
This PR includes:

- Expand Function to Parse and Expand `types.Map` into `map[string]interface`.
- Utility Function to parse a string.
- Changed `Parameters` Expand function to `ExpandParsedFrameworkMapString` in `DNS` and `IPAM` object groups.