### PR TITLE
Bug fix : discovered_tenant and discovered_bridge_domain cannot be empty 

### DIFF
--- a/internal/service/ipam/model_ipv6network.go
+++ b/internal/service/ipam/model_ipv6network.go
@@ -296,6 +296,7 @@ var Ipv6networkResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional:            true,
 		MarkdownDescription: "Discovered bridge domain.",
 		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		Validators: []validator.String{
 			customvalidator.ValidateTrimmedString(),
 		},
@@ -304,6 +305,7 @@ var Ipv6networkResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional:            true,
 		MarkdownDescription: "Discovered tenant.",
 		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		Validators: []validator.String{
 			customvalidator.ValidateTrimmedString(),
 		},
@@ -431,7 +433,7 @@ var Ipv6networkResourceSchemaAttributes = map[string]schema.Attribute{
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: Ipv6networkFederatedRealmsResourceSchemaAttributes,
 		},
-		Optional:            true,
+		Optional: true,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
 		},


### PR DESCRIPTION
fix included - 
ipv6 Network - Cannot set discovered_bridge_domain as empty string
ipv6 Network - Cannot set discovered_tenant as empty string