### PR TITLE
[IPAM][NPS-788] Updated Validate Config for IPV6 network to add check for attribute `ddns_enable_option_fqdn`

### DIFF
--- a/internal/service/ipam/ipv6network_resource.go
+++ b/internal/service/ipam/ipv6network_resource.go
@@ -427,6 +427,18 @@ func (r *Ipv6networkResource) ValidateConfig(ctx context.Context, req resource.V
 		}
 	}
 
+	rirRegistrationStatus := data.RirRegistrationStatus
+	rirOrganization := data.RirOrganization
+
+	if !rirRegistrationStatus.IsNull() && !rirRegistrationStatus.IsUnknown() && rirRegistrationStatus.ValueString() == "REGISTERED" {
+		if rirOrganization.IsNull() || rirOrganization.IsUnknown() {
+			resp.Diagnostics.AddError(
+				"Missing RIR Organization",
+				"The 'rir_organization' attribute must be set when 'rir_registration_status' is set to REGISTERED.",
+			)
+		}
+	}
+
 	ddnsEnableOptionFqdn := data.DdnsEnableOptionFqdn
 	ddnsServerAlwaysUpdates := data.DdnsServerAlwaysUpdates
 
@@ -441,16 +453,5 @@ func (r *Ipv6networkResource) ValidateConfig(ctx context.Context, req resource.V
 			"Invalid DDNS Configuration",
 			"You cannot set 'ddns_server_always_updates' to false when 'ddns_enable_option_fqdn' is false.",
 		)
-	}
-	rirRegistrationStatus := data.RirRegistrationStatus
-	rirOrganization := data.RirOrganization
-
-	if !rirRegistrationStatus.IsNull() && !rirRegistrationStatus.IsUnknown() && rirRegistrationStatus.ValueString() == "REGISTERED" {
-		if rirOrganization.IsNull() || rirOrganization.IsUnknown() {
-			resp.Diagnostics.AddError(
-				"Missing RIR Organization",
-				"The 'rir_organization' attribute must be set when 'rir_registration_status' is set to REGISTERED.",
-			)
-		}
 	}
 }


### PR DESCRIPTION
This PR changes include :

- Updated Validate Config to check that `ddns_server_always_updates` cannot be set to false if `ddns_enable_option_fqdn` is false