### PR TITLE
NPA-954: Added fix for aliases ordering issue for host record

### DIFF
--- a/internal/service/dns/model_ip_allocation.go
+++ b/internal/service/dns/model_ip_allocation.go
@@ -23,54 +23,55 @@ import (
 	"github.com/infobloxopen/infoblox-nios-go-client/dns"
 
 	"github.com/infobloxopen/terraform-provider-nios/internal/flex"
+	internaltypes "github.com/infobloxopen/terraform-provider-nios/internal/types"
 	customvalidator "github.com/infobloxopen/terraform-provider-nios/internal/validator"
 )
 
 type IPAllocationModel struct {
-	Ref                      types.String `tfsdk:"ref"`
-	Aliases                  types.List   `tfsdk:"aliases"`
-	AllowTelnet              types.Bool   `tfsdk:"allow_telnet"`
-	CliCredentials           types.List   `tfsdk:"cli_credentials"`
-	CloudInfo                types.Object `tfsdk:"cloud_info"`
-	Comment                  types.String `tfsdk:"comment"`
-	ConfigureForDns          types.Bool   `tfsdk:"configure_for_dns"`
-	CreationTime             types.Int64  `tfsdk:"creation_time"`
-	DdnsProtected            types.Bool   `tfsdk:"ddns_protected"`
-	DeviceDescription        types.String `tfsdk:"device_description"`
-	DeviceLocation           types.String `tfsdk:"device_location"`
-	DeviceType               types.String `tfsdk:"device_type"`
-	DeviceVendor             types.String `tfsdk:"device_vendor"`
-	Disable                  types.Bool   `tfsdk:"disable"`
-	DisableDiscovery         types.Bool   `tfsdk:"disable_discovery"`
-	DnsAliases               types.List   `tfsdk:"dns_aliases"`
-	DnsName                  types.String `tfsdk:"dns_name"`
-	EnableImmediateDiscovery types.Bool   `tfsdk:"enable_immediate_discovery"`
-	ExtAttrs                 types.Map    `tfsdk:"extattrs"`
-	ExtAttrsAll              types.Map    `tfsdk:"extattrs_all"`
-	InternalID               types.String `tfsdk:"internal_id"`
-	Ipv4addrs                types.List   `tfsdk:"ipv4addrs"`
-	Ipv6addrs                types.List   `tfsdk:"ipv6addrs"`
-	LastQueried              types.Int64  `tfsdk:"last_queried"`
-	MsAdUserData             types.Object `tfsdk:"ms_ad_user_data"`
-	Name                     types.String `tfsdk:"name"`
-	NetworkView              types.String `tfsdk:"network_view"`
-	RestartIfNeeded          types.Bool   `tfsdk:"restart_if_needed"`
-	RrsetOrder               types.String `tfsdk:"rrset_order"`
-	Snmp3Credential          types.Object `tfsdk:"snmp3_credential"`
-	SnmpCredential           types.Object `tfsdk:"snmp_credential"`
-	Ttl                      types.Int64  `tfsdk:"ttl"`
-	UseCliCredentials        types.Bool   `tfsdk:"use_cli_credentials"`
-	UseDnsEaInheritance      types.Bool   `tfsdk:"use_dns_ea_inheritance"`
-	UseSnmp3Credential       types.Bool   `tfsdk:"use_snmp3_credential"`
-	UseSnmpCredential        types.Bool   `tfsdk:"use_snmp_credential"`
-	UseTtl                   types.Bool   `tfsdk:"use_ttl"`
-	View                     types.String `tfsdk:"view"`
-	Zone                     types.String `tfsdk:"zone"`
+	Ref                      types.String                     `tfsdk:"ref"`
+	Aliases                  internaltypes.UnorderedListValue `tfsdk:"aliases"`
+	AllowTelnet              types.Bool                       `tfsdk:"allow_telnet"`
+	CliCredentials           types.List                       `tfsdk:"cli_credentials"`
+	CloudInfo                types.Object                     `tfsdk:"cloud_info"`
+	Comment                  types.String                     `tfsdk:"comment"`
+	ConfigureForDns          types.Bool                       `tfsdk:"configure_for_dns"`
+	CreationTime             types.Int64                      `tfsdk:"creation_time"`
+	DdnsProtected            types.Bool                       `tfsdk:"ddns_protected"`
+	DeviceDescription        types.String                     `tfsdk:"device_description"`
+	DeviceLocation           types.String                     `tfsdk:"device_location"`
+	DeviceType               types.String                     `tfsdk:"device_type"`
+	DeviceVendor             types.String                     `tfsdk:"device_vendor"`
+	Disable                  types.Bool                       `tfsdk:"disable"`
+	DisableDiscovery         types.Bool                       `tfsdk:"disable_discovery"`
+	DnsAliases               types.List                       `tfsdk:"dns_aliases"`
+	DnsName                  types.String                     `tfsdk:"dns_name"`
+	EnableImmediateDiscovery types.Bool                       `tfsdk:"enable_immediate_discovery"`
+	ExtAttrs                 types.Map                        `tfsdk:"extattrs"`
+	ExtAttrsAll              types.Map                        `tfsdk:"extattrs_all"`
+	InternalID               types.String                     `tfsdk:"internal_id"`
+	Ipv4addrs                types.List                       `tfsdk:"ipv4addrs"`
+	Ipv6addrs                types.List                       `tfsdk:"ipv6addrs"`
+	LastQueried              types.Int64                      `tfsdk:"last_queried"`
+	MsAdUserData             types.Object                     `tfsdk:"ms_ad_user_data"`
+	Name                     types.String                     `tfsdk:"name"`
+	NetworkView              types.String                     `tfsdk:"network_view"`
+	RestartIfNeeded          types.Bool                       `tfsdk:"restart_if_needed"`
+	RrsetOrder               types.String                     `tfsdk:"rrset_order"`
+	Snmp3Credential          types.Object                     `tfsdk:"snmp3_credential"`
+	SnmpCredential           types.Object                     `tfsdk:"snmp_credential"`
+	Ttl                      types.Int64                      `tfsdk:"ttl"`
+	UseCliCredentials        types.Bool                       `tfsdk:"use_cli_credentials"`
+	UseDnsEaInheritance      types.Bool                       `tfsdk:"use_dns_ea_inheritance"`
+	UseSnmp3Credential       types.Bool                       `tfsdk:"use_snmp3_credential"`
+	UseSnmpCredential        types.Bool                       `tfsdk:"use_snmp_credential"`
+	UseTtl                   types.Bool                       `tfsdk:"use_ttl"`
+	View                     types.String                     `tfsdk:"view"`
+	Zone                     types.String                     `tfsdk:"zone"`
 }
 
 var IPAllocationAttrTypes = map[string]attr.Type{
 	"ref":                        types.StringType,
-	"aliases":                    types.ListType{ElemType: types.StringType},
+	"aliases":                    internaltypes.UnorderedListOfStringType,
 	"allow_telnet":               types.BoolType,
 	"cli_credentials":            types.ListType{ElemType: types.ObjectType{AttrTypes: RecordHostCliCredentialsAttrTypes}},
 	"cloud_info":                 types.ObjectType{AttrTypes: RecordHostCloudInfoAttrTypes},
@@ -116,6 +117,7 @@ var IPAllocationResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The reference to the object.",
 	},
 	"aliases": schema.ListAttribute{
+		CustomType:          internaltypes.UnorderedListOfStringType,
 		ElementType:         types.StringType,
 		Optional:            true,
 		Computed:            true,
@@ -443,7 +445,7 @@ func (m *IPAllocationModel) Flatten(ctx context.Context, from *dns.RecordHost, d
 		*m = IPAllocationModel{}
 	}
 	m.Ref = flex.FlattenStringPointer(from.Ref)
-	m.Aliases = flex.FlattenFrameworkListString(ctx, from.Aliases, diags)
+	m.Aliases = flex.FlattenFrameworkUnorderedList(ctx, types.StringType, from.Aliases, diags)
 	m.AllowTelnet = types.BoolPointerValue(from.AllowTelnet)
 	m.CliCredentials = flex.FlattenFrameworkListNestedBlock(ctx, from.CliCredentials, RecordHostCliCredentialsAttrTypes, diags, FlattenRecordHostCliCredentials)
 	m.CloudInfo = FlattenRecordHostCloudInfo(ctx, from.CloudInfo, diags)


### PR DESCRIPTION
Issue: Tf throws `Provider produced inconsistent result after apply` error when only the order of aliases is changed in the hcl config.
Root Cause: The NIOS API treats aliases as an unordered collection and does not preserve the order sent in Update requests. When only the order changes (e.g., ["alias1", "alias2"] → ["alias2", "alias1"]), the API considers it a no-op and doesn't update the resource. The Read method then returns the original order from the backend, which differs from the new config order, causing tf to detect an inconsistency.
Fix: Changed aliases attribute from schema.ListAttribute to a custom unordered list type, preventing false inconsistency errors when the API doesn't preserve element order.