### PR TITLE
Remove isCreate Block and Misc Changes for Record PTR , Zone Auth, Notification Rule

### DIFF
--- a/docs/data-sources/dns_zone_auth.md
+++ b/docs/data-sources/dns_zone_auth.md
@@ -65,8 +65,6 @@ Optional:
 - `allow_update_forwarding` (Boolean) The list with IP addresses, networks or TSIG keys for clients, from which forwarded dynamic updates are allowed.
 - `comment` (String) Comment for the zone; maximum 256 characters.
 - `copy_xfer_to_notify` (Boolean) If this flag is set to True then copy allowed IPs from Allow Transfer to Also Notify.
-- `create_ptr_for_bulk_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
-- `create_ptr_for_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
 - `create_underscore_zones` (Boolean) Determines whether automatic creation of subzones is enabled or not.
 - `ddns_force_creation_timestamp_update` (Boolean) Defines whether creation timestamp of RR should be updated ' when DDNS update happens even if there is no change to ' the RR.
 - `ddns_principal_group` (String) The DDNS Principal cluster group name.
@@ -83,7 +81,6 @@ Optional:
 - `dns_integrity_member` (String) The Grid member that performs DNS integrity checks for this zone.
 - `dns_integrity_verbose_logging` (Boolean) If this is set to True, more information is logged for DNS integrity checks for this zone.
 - `dnssec_key_params` (Attributes) The DNSSEC key parameters for the zone. (see [below for nested schema](#nestedatt--result--dnssec_key_params))
-- `do_host_abstraction` (Boolean) Determines if hosts and bulk hosts are automatically created when the zone data is imported. This field is meaningful only when import_from is set.
 - `effective_check_names_policy` (String) The value of the check names policy, which indicates the action the appliance takes when it encounters host names that do not comply with the Strict Hostname Checking policy. This value applies only if the host name restriction policy is set to "Strict Hostname Checking".
 - `extattrs` (Map of String) Extensible attributes associated with the object. For valid values for extensible attributes, see {extattrs:values}.
 - `external_primaries` (Attributes List) The list of external primary servers. (see [below for nested schema](#nestedatt--result--external_primaries))
@@ -145,12 +142,15 @@ Read-Only:
 - `address` (String) The IP address of the server that is serving this zone.
 - `aws_rte53_zone_info` (Attributes) The AWS Route 53 zone information associated with the zone. (see [below for nested schema](#nestedatt--result--aws_rte53_zone_info))
 - `cloud_info` (Attributes) The cloud information associated with the zone. (see [below for nested schema](#nestedatt--result--cloud_info))
+- `create_ptr_for_bulk_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
+- `create_ptr_for_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
 - `display_domain` (String) The displayed name of the DNS zone.
 - `dns_fqdn` (String) The name of this DNS zone in punycode format. For a reverse zone, this is in "address/cidr" format. For other zones, this is in FQDN format in punycode format.
 - `dns_soa_email` (String) The SOA email for the zone in punycode format.
 - `dnssec_keys` (Attributes List) A list of DNSSEC keys for the zone. (see [below for nested schema](#nestedatt--result--dnssec_keys))
 - `dnssec_ksk_rollover_date` (Number) The rollover date for the Key Signing Key.
 - `dnssec_zsk_rollover_date` (Number) The rollover date for the Zone Signing Key.
+- `do_host_abstraction` (Boolean) Determines if hosts and bulk hosts are automatically created when the zone data is imported. This field is meaningful only when import_from is set.
 - `effective_record_name_policy` (String) The selected hostname policy for records under this zone.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object , including default attributes.
 - `grid_primary_shared_with_ms_parent_delegation` (Boolean) Determines if the server is duplicated with parent delegation.

--- a/docs/resources/dns_zone_auth.md
+++ b/docs/resources/dns_zone_auth.md
@@ -98,8 +98,6 @@ resource "nios_dns_zone_auth" "create_zone5" {
 - `allow_update_forwarding` (Boolean) The list with IP addresses, networks or TSIG keys for clients, from which forwarded dynamic updates are allowed.
 - `comment` (String) Comment for the zone; maximum 256 characters.
 - `copy_xfer_to_notify` (Boolean) If this flag is set to True then copy allowed IPs from Allow Transfer to Also Notify.
-- `create_ptr_for_bulk_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
-- `create_ptr_for_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
 - `create_underscore_zones` (Boolean) Determines whether automatic creation of subzones is enabled or not.
 - `ddns_force_creation_timestamp_update` (Boolean) Defines whether creation timestamp of RR should be updated ' when DDNS update happens even if there is no change to ' the RR.
 - `ddns_principal_group` (String) The DDNS Principal cluster group name.
@@ -116,7 +114,6 @@ resource "nios_dns_zone_auth" "create_zone5" {
 - `dns_integrity_member` (String) The Grid member that performs DNS integrity checks for this zone.
 - `dns_integrity_verbose_logging` (Boolean) If this is set to True, more information is logged for DNS integrity checks for this zone.
 - `dnssec_key_params` (Attributes) The DNSSEC key parameters for the zone. (see [below for nested schema](#nestedatt--dnssec_key_params))
-- `do_host_abstraction` (Boolean) Determines if hosts and bulk hosts are automatically created when the zone data is imported. This field is meaningful only when import_from is set.
 - `effective_check_names_policy` (String) The value of the check names policy, which indicates the action the appliance takes when it encounters host names that do not comply with the Strict Hostname Checking policy. This value applies only if the host name restriction policy is set to "Strict Hostname Checking".
 - `extattrs` (Map of String) Extensible attributes associated with the object. For valid values for extensible attributes, see {extattrs:values}.
 - `external_primaries` (Attributes List) The list of external primary servers. (see [below for nested schema](#nestedatt--external_primaries))
@@ -178,12 +175,15 @@ resource "nios_dns_zone_auth" "create_zone5" {
 - `address` (String) The IP address of the server that is serving this zone.
 - `aws_rte53_zone_info` (Attributes) The AWS Route 53 zone information associated with the zone. (see [below for nested schema](#nestedatt--aws_rte53_zone_info))
 - `cloud_info` (Attributes) The cloud information associated with the zone. (see [below for nested schema](#nestedatt--cloud_info))
+- `create_ptr_for_bulk_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
+- `create_ptr_for_hosts` (Boolean) Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.
 - `display_domain` (String) The displayed name of the DNS zone.
 - `dns_fqdn` (String) The name of this DNS zone in punycode format. For a reverse zone, this is in "address/cidr" format. For other zones, this is in FQDN format in punycode format.
 - `dns_soa_email` (String) The SOA email for the zone in punycode format.
 - `dnssec_keys` (Attributes List) A list of DNSSEC keys for the zone. (see [below for nested schema](#nestedatt--dnssec_keys))
 - `dnssec_ksk_rollover_date` (Number) The rollover date for the Key Signing Key.
 - `dnssec_zsk_rollover_date` (Number) The rollover date for the Zone Signing Key.
+- `do_host_abstraction` (Boolean) Determines if hosts and bulk hosts are automatically created when the zone data is imported. This field is meaningful only when import_from is set.
 - `effective_record_name_policy` (String) The selected hostname policy for records under this zone.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object , including default attributes.
 - `grid_primary_shared_with_ms_parent_delegation` (Boolean) Determines if the server is duplicated with parent delegation.

--- a/internal/service/acl/model_namedacl.go
+++ b/internal/service/acl/model_namedacl.go
@@ -100,7 +100,7 @@ var NamedaclResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *NamedaclModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *acl.Namedacl {
+func (m *NamedaclModel) Expand(ctx context.Context, diags *diag.Diagnostics) *acl.Namedacl {
 	if m == nil {
 		return nil
 	}

--- a/internal/service/acl/namedacl_resource.go
+++ b/internal/service/acl/namedacl_resource.go
@@ -82,7 +82,7 @@ func (r *NamedaclResource) Create(ctx context.Context, req resource.CreateReques
 	apiRes, _, err := r.client.ACLAPI.
 		NamedaclAPI.
 		Create(ctx).
-		Namedacl(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Namedacl(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNamedacl).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *NamedaclResource) Update(ctx context.Context, req resource.UpdateReques
 	apiRes, _, err := r.client.ACLAPI.
 		NamedaclAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Namedacl(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Namedacl(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNamedacl).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/cloud/awsrte53taskgroup_resource.go
+++ b/internal/service/cloud/awsrte53taskgroup_resource.go
@@ -82,7 +82,7 @@ func (r *Awsrte53taskgroupResource) Create(ctx context.Context, req resource.Cre
 	apiRes, _, err := r.client.CloudAPI.
 		Awsrte53taskgroupAPI.
 		Create(ctx).
-		Awsrte53taskgroup(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Awsrte53taskgroup(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForAwsrte53taskgroup).
 		ReturnAsObject(1).
 		Execute()
@@ -162,7 +162,7 @@ func (r *Awsrte53taskgroupResource) Update(ctx context.Context, req resource.Upd
 	apiRes, _, err := r.client.CloudAPI.
 		Awsrte53taskgroupAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Awsrte53taskgroup(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Awsrte53taskgroup(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForAwsrte53taskgroup).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/cloud/model_awsrte53taskgroup.go
+++ b/internal/service/cloud/model_awsrte53taskgroup.go
@@ -83,7 +83,7 @@ var Awsrte53taskgroupResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The AWS account IDs file's token.",
 	},
 	"aws_account_ids_file_path": schema.StringAttribute{
-		Optional:            true, 
+		Optional:            true,
 		MarkdownDescription: "The AWS account IDs file's path.",
 	},
 	"comment": schema.StringAttribute{
@@ -195,27 +195,24 @@ var Awsrte53taskgroupResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *Awsrte53taskgroupModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *cloud.Awsrte53taskgroup {
+func (m *Awsrte53taskgroupModel) Expand(ctx context.Context, diags *diag.Diagnostics) *cloud.Awsrte53taskgroup {
 	if m == nil {
 		return nil
 	}
 	to := &cloud.Awsrte53taskgroup{
 		AwsAccountIdsFileToken:     flex.ExpandStringPointer(m.AwsAccountIdsFileToken),
 		Comment:                    flex.ExpandStringPointer(m.Comment),
+		ConsolidatedView:           flex.ExpandStringPointer(m.ConsolidatedView),
+		ConsolidateZones:           flex.ExpandBoolPointer(m.ConsolidateZones),
 		Disabled:                   flex.ExpandBoolPointer(m.Disabled),
 		GridMember:                 flex.ExpandStringPointer(m.GridMember),
 		MultipleAccountsSyncPolicy: flex.ExpandStringPointer(m.MultipleAccountsSyncPolicy),
 		Name:                       flex.ExpandStringPointer(m.Name),
+		NetworkView:                flex.ExpandStringPointer(m.NetworkView),
+		NetworkViewMappingPolicy:   flex.ExpandStringPointer(m.NetworkViewMappingPolicy),
 		RoleArn:                    flex.ExpandStringPointer(m.RoleArn),
 		SyncChildAccounts:          flex.ExpandBoolPointer(m.SyncChildAccounts),
-		TaskList:                   flex.ExpandFrameworkListNestedBlock(ctx, m.TaskList, diags, ExpandAwsrte53taskgroupTaskList),
-	}
-	if isCreate {
-		to.ConsolidateZones = flex.ExpandBoolPointer(m.ConsolidateZones)
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
-		to.ConsolidatedView = flex.ExpandStringPointer(m.ConsolidatedView)
-		to.NetworkViewMappingPolicy = flex.ExpandStringPointer(m.NetworkViewMappingPolicy)
-	}
+		TaskList:                   flex.ExpandFrameworkListNestedBlock(ctx, m.TaskList, diags, ExpandAwsrte53taskgroupTaskList)}
 	return to
 }
 

--- a/internal/service/dhcp/fixedaddress_resource.go
+++ b/internal/service/dhcp/fixedaddress_resource.go
@@ -89,7 +89,7 @@ func (r *FixedaddressResource) Create(ctx context.Context, req resource.CreateRe
 	apiRes, _, err := r.client.DHCPAPI.
 		FixedaddressAPI.
 		Create(ctx).
-		Fixedaddress(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Fixedaddress(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForFixedaddress).
 		ReturnAsObject(1).
 		Execute()
@@ -267,7 +267,7 @@ func (r *FixedaddressResource) Update(ctx context.Context, req resource.UpdateRe
 	apiRes, _, err := r.client.DHCPAPI.
 		FixedaddressAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Fixedaddress(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Fixedaddress(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForFixedaddress).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dhcp/model_fixedaddress.go
+++ b/internal/service/dhcp/model_fixedaddress.go
@@ -629,7 +629,7 @@ var FixedaddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *FixedaddressModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dhcp.Fixedaddress {
+func (m *FixedaddressModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dhcp.Fixedaddress {
 	if m == nil {
 		return nil
 	}
@@ -676,6 +676,7 @@ func (m *FixedaddressModel) Expand(ctx context.Context, diags *diag.Diagnostics,
 		RestartIfNeeded:                flex.ExpandBoolPointer(m.RestartIfNeeded),
 		Snmp3Credential:                ExpandFixedaddressSnmp3Credential(ctx, m.Snmp3Credential, diags),
 		SnmpCredential:                 ExpandFixedaddressSnmpCredential(ctx, m.SnmpCredential, diags),
+		Template:                       flex.ExpandStringPointer(m.Template),
 		UseBootfile:                    flex.ExpandBoolPointer(m.UseBootfile),
 		UseBootserver:                  flex.ExpandBoolPointer(m.UseBootserver),
 		UseCliCredentials:              flex.ExpandBoolPointer(m.UseCliCredentials),
@@ -690,9 +691,6 @@ func (m *FixedaddressModel) Expand(ctx context.Context, diags *diag.Diagnostics,
 		UsePxeLeaseTime:                flex.ExpandBoolPointer(m.UsePxeLeaseTime),
 		UseSnmp3Credential:             flex.ExpandBoolPointer(m.UseSnmp3Credential),
 		UseSnmpCredential:              flex.ExpandBoolPointer(m.UseSnmpCredential),
-	}
-	if isCreate {
-		to.Template = flex.ExpandStringPointer(m.Template)
 	}
 	return to
 }

--- a/internal/service/dhcp/model_range.go
+++ b/internal/service/dhcp/model_range.go
@@ -957,7 +957,7 @@ var RangeResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RangeModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dhcp.Range {
+func (m *RangeModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dhcp.Range {
 	if m == nil {
 		return nil
 	}
@@ -1018,8 +1018,11 @@ func (m *RangeModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCrea
 		RestartIfNeeded:                  flex.ExpandBoolPointer(m.RestartIfNeeded),
 		SamePortControlDiscoveryBlackout: flex.ExpandBoolPointer(m.SamePortControlDiscoveryBlackout),
 		ServerAssociationType:            flex.ExpandStringPointer(m.ServerAssociationType),
+		SplitMember:                      ExpandRangeSplitMember(ctx, m.SplitMember, diags),
+		SplitScopeExclusionPercent:       flex.ExpandInt64Pointer(m.SplitScopeExclusionPercent),
 		StartAddr:                        flex.ExpandIPv4Address(m.StartAddr),
 		SubscribeSettings:                ExpandRangeSubscribeSettings(ctx, m.SubscribeSettings, diags),
+		Template:                         flex.ExpandStringPointer(m.Template),
 		UnknownClients:                   flex.ExpandStringPointer(m.UnknownClients),
 		UpdateDnsOnLeaseRenewal:          flex.ExpandBoolPointer(m.UpdateDnsOnLeaseRenewal),
 		UseBlackoutSetting:               flex.ExpandBoolPointer(m.UseBlackoutSetting),
@@ -1047,11 +1050,6 @@ func (m *RangeModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCrea
 		UseSubscribeSettings:             flex.ExpandBoolPointer(m.UseSubscribeSettings),
 		UseUnknownClients:                flex.ExpandBoolPointer(m.UseUnknownClients),
 		UseUpdateDnsOnLeaseRenewal:       flex.ExpandBoolPointer(m.UseUpdateDnsOnLeaseRenewal),
-	}
-	if isCreate {
-		to.SplitMember = ExpandRangeSplitMember(ctx, m.SplitMember, diags)
-		to.SplitScopeExclusionPercent = flex.ExpandInt64Pointer(m.SplitScopeExclusionPercent)
-		to.Template = flex.ExpandStringPointer(m.Template)
 	}
 	return to
 }

--- a/internal/service/dhcp/model_sharednetwork.go
+++ b/internal/service/dhcp/model_sharednetwork.go
@@ -535,7 +535,7 @@ var SharednetworkResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *SharednetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dhcp.Sharednetwork {
+func (m *SharednetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dhcp.Sharednetwork {
 	if m == nil {
 		return nil
 	}
@@ -564,6 +564,7 @@ func (m *SharednetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics
 		Name:                           flex.ExpandStringPointer(m.Name),
 		Networks:                       flex.ExpandFrameworkListNestedBlock(ctx, m.Networks, diags, ExpandSharednetworkNetworks),
 		Nextserver:                     flex.ExpandStringPointer(m.Nextserver),
+		NetworkView:                    flex.ExpandStringPointer(m.NetworkView),
 		Options:                        flex.ExpandFrameworkListNestedBlock(ctx, m.Options, diags, ExpandSharednetworkOptions),
 		PxeLeaseTime:                   flex.ExpandInt64Pointer(m.PxeLeaseTime),
 		UpdateDnsOnLeaseRenewal:        flex.ExpandBoolPointer(m.UpdateDnsOnLeaseRenewal),
@@ -585,9 +586,6 @@ func (m *SharednetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics
 		UseOptions:                     flex.ExpandBoolPointer(m.UseOptions),
 		UsePxeLeaseTime:                flex.ExpandBoolPointer(m.UsePxeLeaseTime),
 		UseUpdateDnsOnLeaseRenewal:     flex.ExpandBoolPointer(m.UseUpdateDnsOnLeaseRenewal),
-	}
-	if isCreate {
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
 	}
 	return to
 }

--- a/internal/service/dhcp/range_resource.go
+++ b/internal/service/dhcp/range_resource.go
@@ -82,7 +82,7 @@ func (r *RangeResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiRes, _, err := r.client.DHCPAPI.
 		RangeAPI.
 		Create(ctx).
-		Range_(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Range_(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRange).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RangeResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	apiRes, _, err := r.client.DHCPAPI.
 		RangeAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Range_(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Range_(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRange).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dhcp/sharednetwork_resource.go
+++ b/internal/service/dhcp/sharednetwork_resource.go
@@ -187,7 +187,7 @@ func (r *SharednetworkResource) Create(ctx context.Context, req resource.CreateR
 	apiRes, _, err := r.client.DHCPAPI.
 		SharednetworkAPI.
 		Create(ctx).
-		Sharednetwork(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Sharednetwork(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForSharednetwork).
 		ReturnAsObject(1).
 		Execute()
@@ -360,7 +360,7 @@ func (r *SharednetworkResource) Update(ctx context.Context, req resource.UpdateR
 	apiRes, _, err := r.client.DHCPAPI.
 		SharednetworkAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Sharednetwork(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Sharednetwork(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForSharednetwork).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/model_nsgroup.go
+++ b/internal/service/dns/model_nsgroup.go
@@ -163,7 +163,7 @@ var NsgroupResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *NsgroupModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.Nsgroup {
+func (m *NsgroupModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.Nsgroup {
 	if m == nil {
 		return nil
 	}
@@ -175,11 +175,9 @@ func (m *NsgroupModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCr
 		GridPrimary:         flex.ExpandFrameworkListNestedBlock(ctx, m.GridPrimary, diags, ExpandNsgroupGridPrimary),
 		GridSecondaries:     flex.ExpandFrameworkListNestedBlock(ctx, m.GridSecondaries, diags, ExpandNsgroupGridSecondaries),
 		IsGridDefault:       flex.ExpandBoolPointer(m.IsGridDefault),
+		IsMultimaster:       flex.ExpandBoolPointer(m.IsMultimaster),
 		Name:                flex.ExpandStringPointer(m.Name),
 		UseExternalPrimary:  flex.ExpandBoolPointer(m.UseExternalPrimary),
-	}
-	if isCreate {
-		to.IsMultimaster = flex.ExpandBoolPointer(m.IsMultimaster)
 	}
 	return to
 }

--- a/internal/service/dns/model_record_a.go
+++ b/internal/service/dns/model_record_a.go
@@ -236,7 +236,7 @@ var RecordAResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordAModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordA {
+func (m *RecordAModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordA {
 	if m == nil {
 		return nil
 	}
@@ -254,9 +254,7 @@ func (m *RecordAModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCr
 		RemoveAssociatedPtr: flex.ExpandBoolPointer(m.RemoveAssociatedPtr),
 		Ttl:                 flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:              flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:                flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_aaaa.go
+++ b/internal/service/dns/model_record_aaaa.go
@@ -237,7 +237,7 @@ var RecordAaaaResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordAaaaModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordAaaa {
+func (m *RecordAaaaModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordAaaa {
 	if m == nil {
 		return nil
 	}
@@ -255,9 +255,7 @@ func (m *RecordAaaaModel) Expand(ctx context.Context, diags *diag.Diagnostics, i
 		RemoveAssociatedPtr: flex.ExpandBoolPointer(m.RemoveAssociatedPtr),
 		Ttl:                 flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:              flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:                flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_cname.go
+++ b/internal/service/dns/model_record_cname.go
@@ -212,7 +212,7 @@ var RecordCnameResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordCnameModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordCname {
+func (m *RecordCnameModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordCname {
 	if m == nil {
 		return nil
 	}
@@ -228,9 +228,7 @@ func (m *RecordCnameModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		Name:              flex.ExpandStringPointer(m.Name),
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:              flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_dname.go
+++ b/internal/service/dns/model_record_dname.go
@@ -209,7 +209,7 @@ var RecordDnameResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordDnameModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordDname {
+func (m *RecordDnameModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordDname {
 	if m == nil {
 		return nil
 	}
@@ -225,9 +225,7 @@ func (m *RecordDnameModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		Target:            flex.ExpandStringPointer(m.Target),
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:              flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_naptr.go
+++ b/internal/service/dns/model_record_naptr.go
@@ -254,7 +254,7 @@ var RecordNaptrResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordNaptrModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordNaptr {
+func (m *RecordNaptrModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordNaptr {
 	if m == nil {
 		return nil
 	}
@@ -275,9 +275,7 @@ func (m *RecordNaptrModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		Services:          flex.ExpandStringPointer(m.Services),
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:              flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_ns.go
+++ b/internal/service/dns/model_record_ns.go
@@ -122,7 +122,7 @@ var RecordNsResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordNsModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordNs {
+func (m *RecordNsModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordNs {
 	if m == nil {
 		return nil
 	}
@@ -130,10 +130,8 @@ func (m *RecordNsModel) Expand(ctx context.Context, diags *diag.Diagnostics, isC
 		Addresses:        flex.ExpandFrameworkListNestedBlock(ctx, m.Addresses, diags, ExpandRecordNsAddresses),
 		MsDelegationName: flex.ExpandStringPointer(m.MsDelegationName),
 		Nameserver:       flex.ExpandStringPointer(m.Nameserver),
-	}
-	if isCreate {
-		to.Name = flex.ExpandStringPointer(m.Name)
-		to.View = flex.ExpandStringPointer(m.View)
+		Name:             flex.ExpandStringPointer(m.Name),
+		View:             flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_ptr.go
+++ b/internal/service/dns/model_record_ptr.go
@@ -268,7 +268,7 @@ var RecordPtrResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordPtrModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordPtr {
+func (m *RecordPtrModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordPtr {
 	if m == nil {
 		return nil
 	}
@@ -285,9 +285,7 @@ func (m *RecordPtrModel) Expand(ctx context.Context, diags *diag.Diagnostics, is
 		Ptrdname:          flex.ExpandStringPointer(m.Ptrdname),
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:              flex.ExpandStringPointer(m.View),
 	}
 	if !m.Ipv4addr.IsUnknown() {
 		if m.Ipv4addr.ValueString() != "" {

--- a/internal/service/dns/model_record_srv.go
+++ b/internal/service/dns/model_record_srv.go
@@ -244,7 +244,7 @@ var RecordSrvResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordSrvModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordSrv {
+func (m *RecordSrvModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordSrv {
 	if m == nil {
 		return nil
 	}
@@ -263,9 +263,7 @@ func (m *RecordSrvModel) Expand(ctx context.Context, diags *diag.Diagnostics, is
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
 		Weight:            flex.ExpandInt64Pointer(m.Weight),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
+		View:              flex.ExpandStringPointer(m.View),
 	}
 	return to
 }

--- a/internal/service/dns/model_record_txt.go
+++ b/internal/service/dns/model_record_txt.go
@@ -208,7 +208,7 @@ var RecordTxtResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordTxtModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordTxt {
+func (m *RecordTxtModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordTxt {
 	if m == nil {
 		return nil
 	}
@@ -225,9 +225,6 @@ func (m *RecordTxtModel) Expand(ctx context.Context, diags *diag.Diagnostics, is
 		Ttl:               flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:            flex.ExpandBoolPointer(m.UseTtl),
 		View:              flex.ExpandStringPointer(m.View),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
 	}
 	return to
 }

--- a/internal/service/dns/model_record_unknown.go
+++ b/internal/service/dns/model_record_unknown.go
@@ -194,7 +194,7 @@ var RecordUnknownResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *RecordUnknownModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.RecordUnknown {
+func (m *RecordUnknownModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.RecordUnknown {
 	if m == nil {
 		return nil
 	}
@@ -205,13 +205,11 @@ func (m *RecordUnknownModel) Expand(ctx context.Context, diags *diag.Diagnostics
 		EnableHostNamePolicy: flex.ExpandBoolPointer(m.EnableHostNamePolicy),
 		ExtAttrs:             ExpandExtAttrs(ctx, m.ExtAttrs, diags),
 		Name:                 flex.ExpandStringPointer(m.Name),
+		RecordType:           flex.ExpandStringPointer(m.RecordType),
 		SubfieldValues:       flex.ExpandFrameworkListNestedBlock(ctx, m.SubfieldValues, diags, ExpandRecordUnknownSubfieldValues),
 		Ttl:                  flex.ExpandInt64Pointer(m.Ttl),
 		UseTtl:               flex.ExpandBoolPointer(m.UseTtl),
 		View:                 flex.ExpandStringPointer(m.View),
-	}
-	if isCreate {
-		to.RecordType = flex.ExpandStringPointer(m.RecordType)
 	}
 	return to
 }

--- a/internal/service/dns/model_zone_auth.go
+++ b/internal/service/dns/model_zone_auth.go
@@ -400,13 +400,11 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 	},
 	"create_ptr_for_bulk_hosts": schema.BoolAttribute{
-		Optional:            true,
 		Computed:            true,
 		Default:             booldefault.StaticBool(false),
 		MarkdownDescription: "Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.",
 	},
 	"create_ptr_for_hosts": schema.BoolAttribute{
-		Optional:            true,
 		Computed:            true,
 		Default:             booldefault.StaticBool(false),
 		MarkdownDescription: "Determines if PTR records are created for hosts automatically, if necessary, when the zone data is imported. This field is meaningful only when import_from is set.",
@@ -564,7 +562,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The rollover date for the Zone Signing Key.",
 	},
 	"do_host_abstraction": schema.BoolAttribute{
-		Optional:            true,
 		Computed:            true,
 		Default:             booldefault.StaticBool(false),
 		MarkdownDescription: "Determines if hosts and bulk hosts are automatically created when the zone data is imported. This field is meaningful only when import_from is set.",
@@ -1165,7 +1162,7 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *ZoneAuthModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.ZoneAuth {
+func (m *ZoneAuthModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.ZoneAuth {
 	if m == nil {
 		return nil
 	}
@@ -1204,6 +1201,7 @@ func (m *ZoneAuthModel) Expand(ctx context.Context, diags *diag.Diagnostics, isC
 		ExtAttrs:                            ExpandExtAttrs(ctx, m.ExtAttrs, diags),
 		ExternalPrimaries:                   flex.ExpandFrameworkListNestedBlock(ctx, m.ExternalPrimaries, diags, ExpandZoneAuthExternalPrimaries),
 		ExternalSecondaries:                 flex.ExpandFrameworkListNestedBlock(ctx, m.ExternalSecondaries, diags, ExpandZoneAuthExternalSecondaries),
+		Fqdn:                                flex.ExpandStringPointer(m.Fqdn),
 		GridPrimary:                         flex.ExpandFrameworkListNestedBlock(ctx, m.GridPrimary, diags, ExpandZoneAuthGridPrimary),
 		GridSecondaries:                     flex.ExpandFrameworkListNestedBlock(ctx, m.GridSecondaries, diags, ExpandZoneAuthGridSecondaries),
 		LastQueriedAcl:                      flex.ExpandFrameworkListNestedBlock(ctx, m.LastQueriedAcl, diags, ExpandZoneAuthLastQueriedAcl),
@@ -1254,12 +1252,8 @@ func (m *ZoneAuthModel) Expand(ctx context.Context, diags *diag.Diagnostics, isC
 		UseScavengingSettings:               flex.ExpandBoolPointer(m.UseScavengingSettings),
 		UseSoaEmail:                         flex.ExpandBoolPointer(m.UseSoaEmail),
 		View:                                flex.ExpandStringPointer(m.View),
+		ZoneFormat:                          flex.ExpandStringPointer(m.ZoneFormat),
 	}
-	if isCreate {
-		to.Fqdn = flex.ExpandStringPointer(m.Fqdn)
-		to.ZoneFormat = flex.ExpandStringPointer(m.ZoneFormat)
-	}
-
 	return to
 }
 

--- a/internal/service/dns/model_zone_delegated.go
+++ b/internal/service/dns/model_zone_delegated.go
@@ -265,7 +265,7 @@ var ZoneDelegatedResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *ZoneDelegatedModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.ZoneDelegated {
+func (m *ZoneDelegatedModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.ZoneDelegated {
 	if m == nil {
 		return nil
 	}
@@ -276,17 +276,15 @@ func (m *ZoneDelegatedModel) Expand(ctx context.Context, diags *diag.Diagnostics
 		Disable:                flex.ExpandBoolPointer(m.Disable),
 		EnableRfc2317Exclusion: flex.ExpandBoolPointer(m.EnableRfc2317Exclusion),
 		ExtAttrs:               ExpandExtAttrs(ctx, m.ExtAttrs, diags),
+		Fqdn:                   flex.ExpandStringPointer(m.Fqdn),
 		Locked:                 flex.ExpandBoolPointer(m.Locked),
 		MsAdIntegrated:         flex.ExpandBoolPointer(m.MsAdIntegrated),
 		MsDdnsMode:             flex.ExpandStringPointer(m.MsDdnsMode),
 		NsGroup:                flex.ExpandStringPointer(m.NsGroup),
 		Prefix:                 flex.ExpandStringPointer(m.Prefix),
 		UseDelegatedTtl:        flex.ExpandBoolPointer(m.UseDelegatedTtl),
-	}
-	if isCreate {
-		to.View = flex.ExpandStringPointer(m.View)
-		to.Fqdn = flex.ExpandStringPointer(m.Fqdn)
-		to.ZoneFormat = flex.ExpandStringPointer(m.ZoneFormat)
+		View:                   flex.ExpandStringPointer(m.View),
+		ZoneFormat:             flex.ExpandStringPointer(m.ZoneFormat),
 	}
 	return to
 }

--- a/internal/service/dns/model_zone_forward.go
+++ b/internal/service/dns/model_zone_forward.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/infoblox-nios-go-client/dns"
 
@@ -286,19 +285,7 @@ var ZoneForwardResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func ExpandZoneForward(ctx context.Context, o types.Object, diags *diag.Diagnostics, isCreate bool) *dns.ZoneForward {
-	if o.IsNull() || o.IsUnknown() {
-		return nil
-	}
-	var m ZoneForwardModel
-	diags.Append(o.As(ctx, &m, basetypes.ObjectAsOptions{})...)
-	if diags.HasError() {
-		return nil
-	}
-	return m.Expand(ctx, diags, isCreate)
-}
-
-func (m *ZoneForwardModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.ZoneForward {
+func (m *ZoneForwardModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.ZoneForward {
 	if m == nil {
 		return nil
 	}
@@ -311,16 +298,14 @@ func (m *ZoneForwardModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		ForwardTo:           flex.ExpandFrameworkListNestedBlock(ctx, m.ForwardTo, diags, ExpandZoneForwardForwardTo),
 		ForwardersOnly:      flex.ExpandBoolPointer(m.ForwardersOnly),
 		ForwardingServers:   flex.ExpandFrameworkListNestedBlock(ctx, m.ForwardingServers, diags, ExpandZoneForwardForwardingServers),
+		Fqdn:                flex.ExpandStringPointer(m.Fqdn),
 		Locked:              flex.ExpandBoolPointer(m.Locked),
 		MsAdIntegrated:      flex.ExpandBoolPointer(m.MsAdIntegrated),
 		MsDdnsMode:          flex.ExpandStringPointer(m.MsDdnsMode),
 		NsGroup:             flex.ExpandStringPointer(m.NsGroup),
 		Prefix:              flex.ExpandStringPointer(m.Prefix),
-	}
-	if isCreate {
-		to.Fqdn = flex.ExpandStringPointer(m.Fqdn)
-		to.View = flex.ExpandStringPointer(m.View)
-		to.ZoneFormat = flex.ExpandStringPointer(m.ZoneFormat)
+		View:                flex.ExpandStringPointer(m.View),
+		ZoneFormat:          flex.ExpandStringPointer(m.ZoneFormat),
 	}
 	return to
 }

--- a/internal/service/dns/model_zone_rp.go
+++ b/internal/service/dns/model_zone_rp.go
@@ -558,7 +558,7 @@ var ZoneRpResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *ZoneRpModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.ZoneRp {
+func (m *ZoneRpModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.ZoneRp {
 	if m == nil {
 		return nil
 	}
@@ -569,6 +569,7 @@ func (m *ZoneRpModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 		ExternalPrimaries:                flex.ExpandFrameworkListNestedBlock(ctx, m.ExternalPrimaries, diags, ExpandZoneRpExternalPrimaries),
 		ExternalSecondaries:              flex.ExpandFrameworkListNestedBlock(ctx, m.ExternalSecondaries, diags, ExpandZoneRpExternalSecondaries),
 		FireeyeRuleMapping:               ExpandZoneRpFireeyeRuleMapping(ctx, m.FireeyeRuleMapping, diags),
+		Fqdn:                             flex.ExpandStringPointer(m.Fqdn),
 		GridPrimary:                      flex.ExpandFrameworkListNestedBlock(ctx, m.GridPrimary, diags, ExpandZoneRpGridPrimary),
 		GridSecondaries:                  flex.ExpandFrameworkListNestedBlock(ctx, m.GridSecondaries, diags, ExpandZoneRpGridSecondaries),
 		Locked:                           flex.ExpandBoolPointer(m.Locked),
@@ -582,6 +583,7 @@ func (m *ZoneRpModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 		RpzDropIpRuleMinPrefixLengthIpv6: flex.ExpandInt64Pointer(m.RpzDropIpRuleMinPrefixLengthIpv6),
 		RpzPolicy:                        flex.ExpandStringPointer(m.RpzPolicy),
 		RpzSeverity:                      flex.ExpandStringPointer(m.RpzSeverity),
+		RpzType:                          flex.ExpandStringPointer(m.RpzType),
 		SetSoaSerialNumber:               flex.ExpandBoolPointer(m.SetSoaSerialNumber),
 		SoaDefaultTtl:                    flex.ExpandInt64Pointer(m.SoaDefaultTtl),
 		SoaEmail:                         flex.ExpandStringPointer(m.SoaEmail),
@@ -597,15 +599,9 @@ func (m *ZoneRpModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 		UseRecordNamePolicy:              flex.ExpandBoolPointer(m.UseRecordNamePolicy),
 		UseRpzDropIpRule:                 flex.ExpandBoolPointer(m.UseRpzDropIpRule),
 		UseSoaEmail:                      flex.ExpandBoolPointer(m.UseSoaEmail),
-	}
-
-	if isCreate {
-		to.Fqdn = flex.ExpandStringPointer(m.Fqdn)
-		to.RpzType = flex.ExpandStringPointer(m.RpzType)
 		// Zone cannot be moved across views
-		to.View = flex.ExpandStringPointer(m.View)
+		View: flex.ExpandStringPointer(m.View),
 	}
-
 	return to
 }
 

--- a/internal/service/dns/model_zone_stub.go
+++ b/internal/service/dns/model_zone_stub.go
@@ -330,7 +330,7 @@ var ZoneStubResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *ZoneStubModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dns.ZoneStub {
+func (m *ZoneStubModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dns.ZoneStub {
 	if m == nil {
 		return nil
 	}
@@ -340,6 +340,7 @@ func (m *ZoneStubModel) Expand(ctx context.Context, diags *diag.Diagnostics, isC
 		DisableForwarding: flex.ExpandBoolPointer(m.DisableForwarding),
 		ExtAttrs:          ExpandExtAttrs(ctx, m.ExtAttrs, diags),
 		ExternalNsGroup:   flex.ExpandStringPointer(m.ExternalNsGroup),
+		Fqdn:              flex.ExpandStringPointer(m.Fqdn),
 		Locked:            flex.ExpandBoolPointer(m.Locked),
 		MsAdIntegrated:    flex.ExpandBoolPointer(m.MsAdIntegrated),
 		MsDdnsMode:        flex.ExpandStringPointer(m.MsDdnsMode),
@@ -348,14 +349,9 @@ func (m *ZoneStubModel) Expand(ctx context.Context, diags *diag.Diagnostics, isC
 		StubFrom:          flex.ExpandFrameworkListNestedBlock(ctx, m.StubFrom, diags, ExpandZoneStubStubFrom),
 		StubMembers:       flex.ExpandFrameworkListNestedBlock(ctx, m.StubMembers, diags, ExpandZoneStubStubMembers),
 		StubMsservers:     flex.ExpandFrameworkListNestedBlock(ctx, m.StubMsservers, diags, ExpandZoneStubStubMsservers),
+		View:              flex.ExpandStringPointer(m.View),
+		ZoneFormat:        flex.ExpandStringPointer(m.ZoneFormat),
 	}
-
-	if isCreate {
-		to.Fqdn = flex.ExpandStringPointer(m.Fqdn)
-		to.ZoneFormat = flex.ExpandStringPointer(m.ZoneFormat)
-		to.View = flex.ExpandStringPointer(m.View)
-	}
-
 	return to
 }
 

--- a/internal/service/dns/nsgroup_resource.go
+++ b/internal/service/dns/nsgroup_resource.go
@@ -82,7 +82,7 @@ func (r *NsgroupResource) Create(ctx context.Context, req resource.CreateRequest
 	apiRes, _, err := r.client.DNSAPI.
 		NsgroupAPI.
 		Create(ctx).
-		Nsgroup(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Nsgroup(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNsgroup).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *NsgroupResource) Update(ctx context.Context, req resource.UpdateRequest
 	apiRes, _, err := r.client.DNSAPI.
 		NsgroupAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Nsgroup(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Nsgroup(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNsgroup).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_a_resource.go
+++ b/internal/service/dns/record_a_resource.go
@@ -89,7 +89,7 @@ func (r *RecordAResource) Create(ctx context.Context, req resource.CreateRequest
 	apiRes, _, err := r.client.DNSAPI.
 		RecordAAPI.
 		Create(ctx).
-		RecordA(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordA(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordA).
 		ReturnAsObject(1).
 		Execute()
@@ -267,7 +267,7 @@ func (r *RecordAResource) Update(ctx context.Context, req resource.UpdateRequest
 	apiRes, _, err := r.client.DNSAPI.
 		RecordAAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordA(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordA(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordA).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_aaaa_resource.go
+++ b/internal/service/dns/record_aaaa_resource.go
@@ -89,7 +89,7 @@ func (r *RecordAaaaResource) Create(ctx context.Context, req resource.CreateRequ
 	apiRes, _, err := r.client.DNSAPI.
 		RecordAaaaAPI.
 		Create(ctx).
-		RecordAaaa(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordAaaa(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordAaaa).
 		ReturnAsObject(1).
 		Execute()
@@ -267,7 +267,7 @@ func (r *RecordAaaaResource) Update(ctx context.Context, req resource.UpdateRequ
 	apiRes, _, err := r.client.DNSAPI.
 		RecordAaaaAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordAaaa(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordAaaa(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordAaaa).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_cname_resource.go
+++ b/internal/service/dns/record_cname_resource.go
@@ -82,7 +82,7 @@ func (r *RecordCnameResource) Create(ctx context.Context, req resource.CreateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordCnameAPI.
 		Create(ctx).
-		RecordCname(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordCname(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordCname).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordCnameResource) Update(ctx context.Context, req resource.UpdateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordCnameAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordCname(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordCname(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordCname).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_dname_resource.go
+++ b/internal/service/dns/record_dname_resource.go
@@ -82,7 +82,7 @@ func (r *RecordDnameResource) Create(ctx context.Context, req resource.CreateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordDnameAPI.
 		Create(ctx).
-		RecordDname(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordDname(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordDname).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordDnameResource) Update(ctx context.Context, req resource.UpdateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordDnameAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordDname(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordDname(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordDname).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_naptr_resource.go
+++ b/internal/service/dns/record_naptr_resource.go
@@ -82,7 +82,7 @@ func (r *RecordNaptrResource) Create(ctx context.Context, req resource.CreateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordNaptrAPI.
 		Create(ctx).
-		RecordNaptr(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordNaptr(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordNaptr).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordNaptrResource) Update(ctx context.Context, req resource.UpdateReq
 	apiRes, _, err := r.client.DNSAPI.
 		RecordNaptrAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordNaptr(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordNaptr(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordNaptr).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_ns_resource.go
+++ b/internal/service/dns/record_ns_resource.go
@@ -74,7 +74,7 @@ func (r *RecordNsResource) Create(ctx context.Context, req resource.CreateReques
 	apiRes, _, err := r.client.DNSAPI.
 		RecordNsAPI.
 		Create(ctx).
-		RecordNs(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordNs(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordNs).
 		ReturnAsObject(1).
 		Execute()
@@ -147,7 +147,7 @@ func (r *RecordNsResource) Update(ctx context.Context, req resource.UpdateReques
 	apiRes, _, err := r.client.DNSAPI.
 		RecordNsAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordNs(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordNs(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordNs).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_ptr_resource.go
+++ b/internal/service/dns/record_ptr_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	niosclient "github.com/infobloxopen/infoblox-nios-go-client/client"
+	"github.com/infobloxopen/infoblox-nios-go-client/dns"
 
 	"github.com/infobloxopen/terraform-provider-nios/internal/utils"
 )
@@ -114,7 +115,7 @@ func (r *RecordPtrResource) Create(ctx context.Context, req resource.CreateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordPtrAPI.
 		Create(ctx).
-		RecordPtr(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordPtr(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordPtr).
 		ReturnAsObject(1).
 		Execute()
@@ -292,7 +293,7 @@ func (r *RecordPtrResource) Update(ctx context.Context, req resource.UpdateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordPtrAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordPtr(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordPtr(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordPtr).
 		ReturnAsObject(1).
 		Execute()
@@ -355,46 +356,20 @@ func (r *RecordPtrResource) UpdateFuncCallAttributeName(ctx context.Context, dat
 func (r *RecordPtrResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	var diags diag.Diagnostics
 	var data RecordPtrModel
+	var goClientData dns.RecordPtr
 
 	resourceRef := utils.ExtractResourceRef(req.ID)
-
-	apiRes, _, err := r.client.DNSAPI.
-		RecordPtrAPI.
-		Read(ctx, resourceRef).
-		ReturnFieldsPlus(readableAttributesForRecordPtr).
-		ReturnAsObject(1).
-		Execute()
-	if err != nil {
-		resp.Diagnostics.AddError("Import Failed", fmt.Sprintf("Cannot read RecordPtr for import, got error: %s", err))
-		return
-	}
-
-	res := apiRes.GetRecordPtrResponseObjectAsResult.GetResult()
-
-	res.ExtAttrs, data.ExtAttrsAll, diags = RemoveInheritedExtAttrs(ctx, data.ExtAttrs, *res.ExtAttrs)
-	if diags.HasError() {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error while reading RecordPtr for import due inherited Extensible attributes, got error: %s", diags))
-		return
-	}
-
-	data.Flatten(ctx, &res, &resp.Diagnostics)
-
-	planExtAttrs := data.ExtAttrs
-	data.ExtAttrs, diags = AddInheritedExtAttrs(ctx, data.ExtAttrs, data.ExtAttrsAll)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	data.ExtAttrs, diags = AddInternalIDToExtAttrs(ctx, data.ExtAttrs, diags)
+	extattrs, diags := AddInternalIDToExtAttrs(ctx, data.ExtAttrs, diags)
 	if diags.HasError() {
 		return
 	}
+	goClientData.ExtAttrsPlus = ExpandExtAttrs(ctx, extattrs, &diags)
+	data.ExtAttrsAll = extattrs
 
 	updateRes, _, err := r.client.DNSAPI.
 		RecordPtrAPI.
 		Update(ctx, resourceRef).
-		RecordPtr(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordPtr(goClientData).
 		ReturnFieldsPlus(readableAttributesForRecordPtr).
 		ReturnAsObject(1).
 		Execute()
@@ -403,13 +378,14 @@ func (r *RecordPtrResource) ImportState(ctx context.Context, req resource.Import
 		return
 	}
 
-	res = updateRes.UpdateRecordPtrResponseAsObject.GetResult()
+	res := updateRes.UpdateRecordPtrResponseAsObject.GetResult()
 
-	res.ExtAttrs, data.ExtAttrsAll, diags = RemoveInheritedExtAttrs(ctx, planExtAttrs, *res.ExtAttrs)
+	res.ExtAttrs, data.ExtAttrsAll, diags = RemoveInheritedExtAttrs(ctx, data.ExtAttrsAll, *res.ExtAttrs)
 	if diags.HasError() {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Error while update RecordPtr due inherited Extensible attributes for import, got error: %s", diags))
 		return
 	}
+
 	data.Flatten(ctx, &res, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/service/dns/record_srv_resource.go
+++ b/internal/service/dns/record_srv_resource.go
@@ -82,7 +82,7 @@ func (r *RecordSrvResource) Create(ctx context.Context, req resource.CreateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordSrvAPI.
 		Create(ctx).
-		RecordSrv(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordSrv(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordSrv).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordSrvResource) Update(ctx context.Context, req resource.UpdateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordSrvAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordSrv(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordSrv(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordSrv).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_txt_resource.go
+++ b/internal/service/dns/record_txt_resource.go
@@ -82,7 +82,7 @@ func (r *RecordTxtResource) Create(ctx context.Context, req resource.CreateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordTxtAPI.
 		Create(ctx).
-		RecordTxt(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordTxt(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordTxt).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordTxtResource) Update(ctx context.Context, req resource.UpdateReque
 	apiRes, _, err := r.client.DNSAPI.
 		RecordTxtAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordTxt(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordTxt(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordTxt).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/record_unknown_resource.go
+++ b/internal/service/dns/record_unknown_resource.go
@@ -82,7 +82,7 @@ func (r *RecordUnknownResource) Create(ctx context.Context, req resource.CreateR
 	apiRes, _, err := r.client.DNSAPI.
 		RecordUnknownAPI.
 		Create(ctx).
-		RecordUnknown(*data.Expand(ctx, &resp.Diagnostics, true)).
+		RecordUnknown(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordUnknown).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *RecordUnknownResource) Update(ctx context.Context, req resource.UpdateR
 	apiRes, _, err := r.client.DNSAPI.
 		RecordUnknownAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		RecordUnknown(*data.Expand(ctx, &resp.Diagnostics, false)).
+		RecordUnknown(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForRecordUnknown).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/zone_auth_resource.go
+++ b/internal/service/dns/zone_auth_resource.go
@@ -140,7 +140,7 @@ func (r *ZoneAuthResource) Create(ctx context.Context, req resource.CreateReques
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneAuthAPI.
 		Create(ctx).
-		ZoneAuth(*data.Expand(ctx, &resp.Diagnostics, true)).
+		ZoneAuth(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneAuth).
 		ReturnAsObject(1).
 		Execute()
@@ -313,7 +313,7 @@ func (r *ZoneAuthResource) Update(ctx context.Context, req resource.UpdateReques
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneAuthAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		ZoneAuth(*data.Expand(ctx, &resp.Diagnostics, false)).
+		ZoneAuth(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneAuth).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/zone_delegated_resource.go
+++ b/internal/service/dns/zone_delegated_resource.go
@@ -82,7 +82,7 @@ func (r *ZoneDelegatedResource) Create(ctx context.Context, req resource.CreateR
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneDelegatedAPI.
 		Create(ctx).
-		ZoneDelegated(*data.Expand(ctx, &resp.Diagnostics, true)).
+		ZoneDelegated(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneDelegated).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *ZoneDelegatedResource) Update(ctx context.Context, req resource.UpdateR
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneDelegatedAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		ZoneDelegated(*data.Expand(ctx, &resp.Diagnostics, false)).
+		ZoneDelegated(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneDelegated).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/zone_forward_resource.go
+++ b/internal/service/dns/zone_forward_resource.go
@@ -82,7 +82,7 @@ func (r *ZoneForwardResource) Create(ctx context.Context, req resource.CreateReq
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneForwardAPI.
 		Create(ctx).
-		ZoneForward(*data.Expand(ctx, &resp.Diagnostics, true)).
+		ZoneForward(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneForward).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *ZoneForwardResource) Update(ctx context.Context, req resource.UpdateReq
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneForwardAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		ZoneForward(*data.Expand(ctx, &resp.Diagnostics, false)).
+		ZoneForward(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneForward).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/zone_rp_resource.go
+++ b/internal/service/dns/zone_rp_resource.go
@@ -135,7 +135,7 @@ func (r *ZoneRpResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneRpAPI.
 		Create(ctx).
-		ZoneRp(*data.Expand(ctx, &resp.Diagnostics, true)).
+		ZoneRp(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneRp).
 		ReturnAsObject(1).
 		Execute()
@@ -308,7 +308,7 @@ func (r *ZoneRpResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneRpAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		ZoneRp(*data.Expand(ctx, &resp.Diagnostics, false)).
+		ZoneRp(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneRp).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/dns/zone_stub_resource.go
+++ b/internal/service/dns/zone_stub_resource.go
@@ -82,7 +82,7 @@ func (r *ZoneStubResource) Create(ctx context.Context, req resource.CreateReques
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneStubAPI.
 		Create(ctx).
-		ZoneStub(*data.Expand(ctx, &resp.Diagnostics, true)).
+		ZoneStub(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneStub).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *ZoneStubResource) Update(ctx context.Context, req resource.UpdateReques
 	apiRes, _, err := r.client.DNSAPI.
 		ZoneStubAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		ZoneStub(*data.Expand(ctx, &resp.Diagnostics, false)).
+		ZoneStub(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForZoneStub).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/grid/extensibleattributedef_resource.go
+++ b/internal/service/grid/extensibleattributedef_resource.go
@@ -74,7 +74,7 @@ func (r *ExtensibleattributedefResource) Create(ctx context.Context, req resourc
 	apiRes, _, err := r.client.GridAPI.
 		ExtensibleattributedefAPI.
 		Create(ctx).
-		Extensibleattributedef(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Extensibleattributedef(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForExtensibleattributedef).
 		ReturnAsObject(1).
 		Execute()
@@ -147,7 +147,7 @@ func (r *ExtensibleattributedefResource) Update(ctx context.Context, req resourc
 	apiRes, _, err := r.client.GridAPI.
 		ExtensibleattributedefAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Extensibleattributedef(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Extensibleattributedef(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForExtensibleattributedef).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/grid/model_extensibleattributedef.go
+++ b/internal/service/grid/model_extensibleattributedef.go
@@ -133,7 +133,7 @@ var ExtensibleattributedefResourceSchemaAttributes = map[string]schema.Attribute
 	},
 }
 
-func (m *ExtensibleattributedefModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *grid.Extensibleattributedef {
+func (m *ExtensibleattributedefModel) Expand(ctx context.Context, diags *diag.Diagnostics) *grid.Extensibleattributedef {
 	if m == nil {
 		return nil
 	}
@@ -147,9 +147,7 @@ func (m *ExtensibleattributedefModel) Expand(ctx context.Context, diags *diag.Di
 		Max:                flex.ExpandInt64Pointer(m.Max),
 		Min:                flex.ExpandInt64Pointer(m.Min),
 		Name:               flex.ExpandStringPointer(m.Name),
-	}
-	if isCreate {
-		to.Type = flex.ExpandStringPointer(m.Type)
+		Type:               flex.ExpandStringPointer(m.Type),
 	}
 	return to
 }

--- a/internal/service/ipam/ipv6network_resource.go
+++ b/internal/service/ipam/ipv6network_resource.go
@@ -90,7 +90,7 @@ func (r *Ipv6networkResource) Create(ctx context.Context, req resource.CreateReq
 	apiRes, _, err := r.client.IPAMAPI.
 		Ipv6networkAPI.
 		Create(ctx).
-		Ipv6network(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Ipv6network(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForIpv6network).
 		ReturnAsObject(1).
 		Execute()
@@ -281,7 +281,7 @@ func (r *Ipv6networkResource) Update(ctx context.Context, req resource.UpdateReq
 	apiRes, _, err := r.client.IPAMAPI.
 		Ipv6networkAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Ipv6network(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Ipv6network(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForIpv6network).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/ipam/ipv6networkcontainer_resource.go
+++ b/internal/service/ipam/ipv6networkcontainer_resource.go
@@ -89,7 +89,7 @@ func (r *Ipv6networkcontainerResource) Create(ctx context.Context, req resource.
 	apiRes, _, err := r.client.IPAMAPI.
 		Ipv6networkcontainerAPI.
 		Create(ctx).
-		Ipv6networkcontainer(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Ipv6networkcontainer(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForIpv6networkcontainer).
 		ReturnAsObject(1).
 		Execute()
@@ -267,7 +267,7 @@ func (r *Ipv6networkcontainerResource) Update(ctx context.Context, req resource.
 	apiRes, _, err := r.client.IPAMAPI.
 		Ipv6networkcontainerAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Ipv6networkcontainer(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Ipv6networkcontainer(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForIpv6networkcontainer).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/ipam/model_ipv6network.go
+++ b/internal/service/ipam/model_ipv6network.go
@@ -806,11 +806,12 @@ var Ipv6networkResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *Ipv6networkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *ipam.Ipv6network {
+func (m *Ipv6networkModel) Expand(ctx context.Context, diags *diag.Diagnostics) *ipam.Ipv6network {
 	if m == nil {
 		return nil
 	}
 	to := &ipam.Ipv6network{
+		AutoCreateReversezone:            flex.ExpandBoolPointer(m.AutoCreateReversezone),
 		CloudInfo:                        ExpandIpv6networkCloudInfo(ctx, m.CloudInfo, diags),
 		Comment:                          flex.ExpandStringPointer(m.Comment),
 		DdnsDomainname:                   flex.ExpandStringPointer(m.DdnsDomainname),
@@ -838,8 +839,9 @@ func (m *Ipv6networkModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		MgmPrivate:                       flex.ExpandBoolPointer(m.MgmPrivate),
 		MsAdUserData:                     ExpandIpv6networkMsAdUserData(ctx, m.MsAdUserData, diags),
 		Network:                          ExpandIpv6NetworkNetwork(m.Network),
-		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
+		NetworkContainer:                 flex.ExpandStringPointer(m.NetworkContainer),
 		NetworkView:                      flex.ExpandStringPointer(m.NetworkView),
+		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
 		Options:                          flex.ExpandFrameworkListNestedBlock(ctx, m.Options, diags, ExpandIpv6networkOptions),
 		PortControlBlackoutSetting:       ExpandIpv6networkPortControlBlackoutSetting(ctx, m.PortControlBlackoutSetting, diags),
 		PreferredLifetime:                flex.ExpandInt64Pointer(m.PreferredLifetime),
@@ -877,12 +879,6 @@ func (m *Ipv6networkModel) Expand(ctx context.Context, diags *diag.Diagnostics, 
 		ValidLifetime:                    flex.ExpandInt64Pointer(m.ValidLifetime),
 		Vlans:                            flex.ExpandFrameworkListNestedBlock(ctx, m.Vlans, diags, ExpandIpv6networkVlans),
 		ZoneAssociations:                 flex.ExpandFrameworkListNestedBlock(ctx, m.ZoneAssociations, diags, ExpandIpv6networkZoneAssociations),
-	}
-	if isCreate {
-		to.NetworkContainer = flex.ExpandStringPointer(m.NetworkContainer)
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
-		to.Network = ExpandIpv6NetworkNetwork(m.Network)
-		to.AutoCreateReversezone = flex.ExpandBoolPointer(m.AutoCreateReversezone)
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipv6networkcontainer.go
+++ b/internal/service/ipam/model_ipv6networkcontainer.go
@@ -644,11 +644,12 @@ var Ipv6networkcontainerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *Ipv6networkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *ipam.Ipv6networkcontainer {
+func (m *Ipv6networkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnostics) *ipam.Ipv6networkcontainer {
 	if m == nil {
 		return nil
 	}
 	to := &ipam.Ipv6networkcontainer{
+		AutoCreateReversezone:            flex.ExpandBoolPointer(m.AutoCreateReversezone),
 		CloudInfo:                        ExpandIpv6networkcontainerCloudInfo(ctx, m.CloudInfo, diags),
 		Comment:                          flex.ExpandStringPointer(m.Comment),
 		DdnsDomainname:                   flex.ExpandStringPointer(m.DdnsDomainname),
@@ -670,8 +671,9 @@ func (m *Ipv6networkcontainerModel) Expand(ctx context.Context, diags *diag.Diag
 		MgmPrivate:                       flex.ExpandBoolPointer(m.MgmPrivate),
 		MsAdUserData:                     ExpandIpv6networkcontainerMsAdUserData(ctx, m.MsAdUserData, diags),
 		Network:                          ExpandIpv6NetworkcontainerNetwork(m.Network),
-		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
+		NetworkContainer:                 flex.ExpandStringPointer(m.NetworkContainer),
 		NetworkView:                      flex.ExpandStringPointer(m.NetworkView),
+		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
 		Options:                          flex.ExpandFrameworkListNestedBlock(ctx, m.Options, diags, ExpandIpv6networkcontainerOptions),
 		PortControlBlackoutSetting:       ExpandIpv6networkcontainerPortControlBlackoutSetting(ctx, m.PortControlBlackoutSetting, diags),
 		PreferredLifetime:                flex.ExpandInt64Pointer(m.PreferredLifetime),
@@ -704,12 +706,6 @@ func (m *Ipv6networkcontainerModel) Expand(ctx context.Context, diags *diag.Diag
 		UseZoneAssociations:              flex.ExpandBoolPointer(m.UseZoneAssociations),
 		ValidLifetime:                    flex.ExpandInt64Pointer(m.ValidLifetime),
 		ZoneAssociations:                 flex.ExpandFrameworkListNestedBlock(ctx, m.ZoneAssociations, diags, ExpandIpv6networkcontainerZoneAssociations),
-	}
-	if isCreate {
-		to.NetworkContainer = flex.ExpandStringPointer(m.NetworkContainer)
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
-		to.Network = ExpandIpv6NetworkcontainerNetwork(m.Network)
-		to.AutoCreateReversezone = flex.ExpandBoolPointer(m.AutoCreateReversezone)
 	}
 	return to
 }

--- a/internal/service/ipam/model_network.go
+++ b/internal/service/ipam/model_network.go
@@ -1170,7 +1170,7 @@ var NetworkResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *NetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *ipam.Network {
+func (m *NetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics) *ipam.Network {
 	if m == nil {
 		return nil
 	}
@@ -1224,6 +1224,9 @@ func (m *NetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCr
 		MgmPrivate:                       flex.ExpandBoolPointer(m.MgmPrivate),
 		MsAdUserData:                     ExpandNetworkMsAdUserData(ctx, m.MsAdUserData, diags),
 		Netmask:                          flex.ExpandInt64Pointer(m.Netmask),
+		Network:                          ExpandNetworkNetwork(m.Network),
+		NetworkContainer:                 flex.ExpandStringPointer(m.NetworkContainer),
+		NetworkView:                      flex.ExpandStringPointer(m.NetworkView),
 		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
 		Nextserver:                       flex.ExpandStringPointer(m.Nextserver),
 		Options:                          flex.ExpandFrameworkListNestedBlock(ctx, m.Options, diags, ExpandNetworkOptions),
@@ -1237,6 +1240,7 @@ func (m *NetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCr
 		SamePortControlDiscoveryBlackout: flex.ExpandBoolPointer(m.SamePortControlDiscoveryBlackout),
 		SendRirRequest:                   flex.ExpandBoolPointer(m.SendRirRequest),
 		SubscribeSettings:                ExpandNetworkSubscribeSettings(ctx, m.SubscribeSettings, diags),
+		Template:                         flex.ExpandStringPointer(m.Template),
 		Unmanaged:                        flex.ExpandBoolPointer(m.Unmanaged),
 		UpdateDnsOnLeaseRenewal:          flex.ExpandBoolPointer(m.UpdateDnsOnLeaseRenewal),
 		UseAuthority:                     flex.ExpandBoolPointer(m.UseAuthority),
@@ -1272,13 +1276,6 @@ func (m *NetworkModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCr
 		UseZoneAssociations:              flex.ExpandBoolPointer(m.UseZoneAssociations),
 		Vlans:                            flex.ExpandFrameworkListNestedBlock(ctx, m.Vlans, diags, ExpandNetworkVlans),
 		ZoneAssociations:                 flex.ExpandFrameworkListNestedBlock(ctx, m.ZoneAssociations, diags, ExpandNetworkZoneAssociations),
-	}
-	if isCreate {
-		to.NetworkContainer = flex.ExpandStringPointer(m.NetworkContainer)
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
-		to.Network = ExpandNetworkNetwork(m.Network)
-		to.Template = flex.ExpandStringPointer(m.Template)
-		to.AutoCreateReversezone = flex.ExpandBoolPointer(m.AutoCreateReversezone)
 	}
 	return to
 }

--- a/internal/service/ipam/model_networkcontainer.go
+++ b/internal/service/ipam/model_networkcontainer.go
@@ -965,7 +965,7 @@ var NetworkcontainerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *NetworkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *ipam.Networkcontainer {
+func (m *NetworkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnostics) *ipam.Networkcontainer {
 	if m == nil {
 		return nil
 	}
@@ -1011,8 +1011,10 @@ func (m *NetworkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnost
 		LowWaterMarkReset:                flex.ExpandInt64Pointer(m.LowWaterMarkReset),
 		MgmPrivate:                       flex.ExpandBoolPointer(m.MgmPrivate),
 		MsAdUserData:                     ExpandNetworkcontainerMsAdUserData(ctx, m.MsAdUserData, diags),
-		Network:                          ExpandNetworkcontainerNetwork(m.Network),
 		FuncCall:                         ExpandFuncCall(ctx, m.FuncCall, diags),
+		Network:                          ExpandNetworkcontainerNetwork(m.Network),
+		NetworkContainer:                 flex.ExpandStringPointer(m.NetworkContainer),
+		NetworkView:                      flex.ExpandStringPointer(m.NetworkView),
 		Nextserver:                       flex.ExpandStringPointer(m.Nextserver),
 		Options:                          flex.ExpandFrameworkListNestedBlock(ctx, m.Options, diags, ExpandNetworkcontainerOptions),
 		PortControlBlackoutSetting:       ExpandNetworkcontainerPortControlBlackoutSetting(ctx, m.PortControlBlackoutSetting, diags),
@@ -1059,11 +1061,6 @@ func (m *NetworkcontainerModel) Expand(ctx context.Context, diags *diag.Diagnost
 		UseUpdateDnsOnLeaseRenewal:       flex.ExpandBoolPointer(m.UseUpdateDnsOnLeaseRenewal),
 		UseZoneAssociations:              flex.ExpandBoolPointer(m.UseZoneAssociations),
 		ZoneAssociations:                 flex.ExpandFrameworkListNestedBlock(ctx, m.ZoneAssociations, diags, ExpandNetworkcontainerZoneAssociations),
-	}
-	if isCreate {
-		to.NetworkContainer = flex.ExpandStringPointer(m.NetworkContainer)
-		to.NetworkView = flex.ExpandStringPointer(m.NetworkView)
-		to.Network = ExpandNetworkcontainerNetwork(m.Network)
 	}
 	return to
 }

--- a/internal/service/ipam/network_resource.go
+++ b/internal/service/ipam/network_resource.go
@@ -91,7 +91,7 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 	apiRes, _, err := r.client.IPAMAPI.
 		NetworkAPI.
 		Create(ctx).
-		Network(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Network(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNetwork).
 		ReturnAsObject(1).
 		Execute()
@@ -282,7 +282,7 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 	apiRes, _, err := r.client.IPAMAPI.
 		NetworkAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Network(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Network(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNetwork).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/ipam/networkcontainer_resource.go
+++ b/internal/service/ipam/networkcontainer_resource.go
@@ -89,7 +89,7 @@ func (r *NetworkcontainerResource) Create(ctx context.Context, req resource.Crea
 	apiRes, _, err := r.client.IPAMAPI.
 		NetworkcontainerAPI.
 		Create(ctx).
-		Networkcontainer(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Networkcontainer(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNetworkcontainer).
 		ReturnAsObject(1).
 		Execute()
@@ -267,7 +267,7 @@ func (r *NetworkcontainerResource) Update(ctx context.Context, req resource.Upda
 	apiRes, _, err := r.client.IPAMAPI.
 		NetworkcontainerAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Networkcontainer(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Networkcontainer(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNetworkcontainer).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/notification/model_notification_rule.go
+++ b/internal/service/notification/model_notification_rule.go
@@ -211,7 +211,7 @@ var NotificationRuleResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *NotificationRuleModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *notification.NotificationRule {
+func (m *NotificationRuleModel) Expand(ctx context.Context, diags *diag.Diagnostics) *notification.NotificationRule {
 	if m == nil {
 		return nil
 	}
@@ -225,15 +225,13 @@ func (m *NotificationRuleModel) Expand(ctx context.Context, diags *diag.Diagnost
 		EventPriority:                    flex.ExpandStringPointer(m.EventPriority),
 		EventType:                        flex.ExpandStringPointer(m.EventType),
 		ExpressionList:                   flex.ExpandFrameworkListNestedBlock(ctx, m.ExpressionList, diags, ExpandNotificationRuleExpressionList),
+		Name:                             flex.ExpandStringPointer(m.Name),
 		NotificationAction:               flex.ExpandStringPointer(m.NotificationAction),
 		NotificationTarget:               flex.ExpandStringPointer(m.NotificationTarget.StringValue),
 		PublishSettings:                  ExpandNotificationRulePublishSettings(ctx, m.PublishSettings, diags),
 		ScheduledEvent:                   ExpandNotificationRuleScheduledEvent(ctx, m.ScheduledEvent, diags),
 		TemplateInstance:                 ExpandNotificationRuleTemplateInstance(ctx, m.TemplateInstance, diags),
 		UsePublishSettings:               flex.ExpandBoolPointer(m.UsePublishSettings),
-	}
-	if isCreate {
-		to.Name = flex.ExpandStringPointer(m.Name)
 	}
 	return to
 }

--- a/internal/service/notification/model_notification_rule_scheduled_event.go
+++ b/internal/service/notification/model_notification_rule_scheduled_event.go
@@ -61,7 +61,6 @@ var NotificationRuleScheduledEventResourceSchemaAttributes = map[string]schema.A
 				stringvalidator.OneOf("MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"),
 			),
 			listvalidator.SizeAtLeast(1),
-			listvalidator.ValueStringsAre(stringvalidator.OneOf("SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY")),
 		},
 		Optional:            true,
 		MarkdownDescription: "Days of the week when scheduling is triggered.",

--- a/internal/service/notification/notification_rule_resource.go
+++ b/internal/service/notification/notification_rule_resource.go
@@ -74,7 +74,7 @@ func (r *NotificationRuleResource) Create(ctx context.Context, req resource.Crea
 	apiRes, _, err := r.client.NotificationAPI.
 		NotificationRuleAPI.
 		Create(ctx).
-		NotificationRule(*data.Expand(ctx, &resp.Diagnostics, true)).
+		NotificationRule(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNotificationRule).
 		ReturnAsObject(1).
 		Execute()
@@ -147,7 +147,7 @@ func (r *NotificationRuleResource) Update(ctx context.Context, req resource.Upda
 	apiRes, _, err := r.client.NotificationAPI.
 		NotificationRuleAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		NotificationRule(*data.Expand(ctx, &resp.Diagnostics, false)).
+		NotificationRule(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForNotificationRule).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/security/ftpuser_resource.go
+++ b/internal/service/security/ftpuser_resource.go
@@ -82,7 +82,7 @@ func (r *FtpuserResource) Create(ctx context.Context, req resource.CreateRequest
 	apiRes, _, err := r.client.SecurityAPI.
 		FtpuserAPI.
 		Create(ctx).
-		Ftpuser(*data.Expand(ctx, &resp.Diagnostics, true)).
+		Ftpuser(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForFtpuser).
 		ReturnAsObject(1).
 		Execute()
@@ -255,7 +255,7 @@ func (r *FtpuserResource) Update(ctx context.Context, req resource.UpdateRequest
 	apiRes, _, err := r.client.SecurityAPI.
 		FtpuserAPI.
 		Update(ctx, utils.ExtractResourceRef(data.Ref.ValueString())).
-		Ftpuser(*data.Expand(ctx, &resp.Diagnostics, false)).
+		Ftpuser(*data.Expand(ctx, &resp.Diagnostics)).
 		ReturnFieldsPlus(readableAttributesForFtpuser).
 		ReturnAsObject(1).
 		Execute()

--- a/internal/service/security/model_ftpuser.go
+++ b/internal/service/security/model_ftpuser.go
@@ -107,19 +107,17 @@ var FtpuserResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *FtpuserModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *security.Ftpuser {
+func (m *FtpuserModel) Expand(ctx context.Context, diags *diag.Diagnostics) *security.Ftpuser {
 	if m == nil {
 		return nil
 	}
 	to := &security.Ftpuser{
-		ExtAttrs:   ExpandExtAttrs(ctx, m.ExtAttrs, diags),
-		Permission: flex.ExpandStringPointer(m.Permission),
-		Password:   flex.ExpandStringPointer(m.Password),
-	}
-	if isCreate {
-		to.CreateHomeDir = flex.ExpandBoolPointer(m.CreateHomeDir)
-		to.HomeDir = flex.ExpandStringPointer(m.HomeDir)
-		to.Username = flex.ExpandStringPointer(m.Username)
+		CreateHomeDir: flex.ExpandBoolPointer(m.CreateHomeDir),
+		ExtAttrs:      ExpandExtAttrs(ctx, m.ExtAttrs, diags),
+		HomeDir:       flex.ExpandStringPointer(m.HomeDir),
+		Permission:    flex.ExpandStringPointer(m.Permission),
+		Password:      flex.ExpandStringPointer(m.Password),
+		Username:      flex.ExpandStringPointer(m.Username),
 	}
 	return to
 }


### PR DESCRIPTION
- Removed the `isCreate` block from the model and resource files of all objects
- Regenerated `record_ptr_resource.go` to update the import function
- NPA - 826 - Marked `create_ptr_for_bulk_hosts` `create_ptr_for_hosts` and `do_host_abstraction` as Computed
- Removed duplicate validator from `model_notification_rule_scheduled_event.go`