### PR TITLE
[GRID] Bug Fixes for ExtensibleAttributeDef

### DIFF
--- a/internal/service/grid/extensibleattributedef_resource.go
+++ b/internal/service/grid/extensibleattributedef_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -214,6 +215,21 @@ func (r *ExtensibleattributedefResource) ValidateConfig(ctx context.Context, req
 			"Invalid Min/Max Configuration",
 			fmt.Sprintf("The 'min' and 'max' attributes are only valid for INTEGER and STRING extensible attribute types, but type is %q. Remove min and max attributes or change the type to INTEGER or STRING.", typeValue),
 		)
+	}
+
+	// Check if type is INTEGER, then default_value should be a valid integer
+	if !data.DefaultValue.IsNull() && !data.DefaultValue.IsUnknown() {
+		if typeValue == "INTEGER" {
+			defaultValue := data.DefaultValue.ValueString()
+			_, err := strconv.ParseInt(defaultValue, 10, 32)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Invalid Integer Default Value",
+					fmt.Sprintf("The default_value '%s' is not a valid integer.", defaultValue),
+				)
+				return
+			}
+		}
 	}
 }
 

--- a/internal/service/grid/extensibleattributedef_resource_test.go
+++ b/internal/service/grid/extensibleattributedef_resource_test.go
@@ -284,15 +284,6 @@ func TestAccExtensibleattributedefResource_Max(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", eaType),
 				),
 			},
-			// Update and Read
-			{
-				Config: testAccExtensibleattributedefMax(name, 200, eaType),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckExtensibleattributedefExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "max", "200"),
-					resource.TestCheckResourceAttr(resourceName, "type", eaType),
-				),
-			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/service/grid/model_extensibleattributedef.go
+++ b/internal/service/grid/model_extensibleattributedef.go
@@ -104,13 +104,19 @@ var ExtensibleattributedefResourceSchemaAttributes = map[string]schema.Attribute
 		MarkdownDescription: "List of Values. Applicable if the extensible attribute type is ENUM.",
 	},
 	"max": schema.Int64Attribute{
-		Optional:            true,
-		Computed:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.Int64{
+			planmodifiers.ImmutableInt64(),
+		},
 		MarkdownDescription: "Maximum allowed value of extensible attribute. Applicable if the extensible attribute type is INTEGER.",
 	},
 	"min": schema.Int64Attribute{
-		Optional:            true,
-		Computed:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.Int64{
+			planmodifiers.ImmutableInt64(),
+		},
 		MarkdownDescription: "Minimum allowed value of extensible attribute. Applicable if the extensible attribute type is INTEGER.",
 	},
 	"name": schema.StringAttribute{
@@ -188,12 +194,12 @@ func (m *ExtensibleattributedefModel) Flatten(ctx context.Context, from *grid.Ex
 
 func ExpandExtensibleAttributeDefDefaultValue(ctx context.Context, defaultValue types.String, eaType types.String, diags *diag.Diagnostics) *grid.ExtensibleattributedefDefaultValue {
 	if defaultValue.IsNull() || defaultValue.IsUnknown() {
-		return &grid.ExtensibleattributedefDefaultValue{}
+		return nil
 	}
 
 	value := defaultValue.ValueString()
 	if value == "" {
-		return &grid.ExtensibleattributedefDefaultValue{}
+		return nil
 	}
 
 	// Check the type to determine if we should send as integer or string
@@ -209,7 +215,7 @@ func ExpandExtensibleAttributeDefDefaultValue(ctx context.Context, defaultValue 
 				"Invalid Integer Default Value",
 				fmt.Sprintf("Cannot convert default_value '%s' to integer: %v", value, err),
 			)
-			return &grid.ExtensibleattributedefDefaultValue{}
+			return nil
 		}
 	}
 


### PR DESCRIPTION
- NPA - 1024 - Fixed Marshalling issue by passing nil instead of `grid.ExtensibleattributedefDefaultValue{}` in `ExpandExtensibleAttributeDefDefaultValue`
- NPA - 930 - Added immutable Plan Modifier for non-updatable fields
- Added Validate config to check if default_value is a valid integer when type is `INTEGER`