### PR TITLE
[DNS][DTC] Fix TTL issue for Record PTR and DTC Pool

### DIFF
--- a/internal/service/dns/model_record_ptr.go
+++ b/internal/service/dns/model_record_ptr.go
@@ -242,6 +242,7 @@ var RecordPtrResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ttl": schema.Int64Attribute{
 		Optional: true,
+		Computed: true,
 		Validators: []validator.Int64{
 			int64validator.AlsoRequires(path.MatchRoot("use_ttl")),
 		},

--- a/internal/service/dtc/model_dtc_pool.go
+++ b/internal/service/dtc/model_dtc_pool.go
@@ -209,6 +209,7 @@ var DtcPoolResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ttl": schema.Int64Attribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "The Time To Live (TTL) value for the DTC Pool. A 32-bit unsigned integer that represents the duration, in seconds, for which the record is valid (cached). Zero indicates that the record should not be cached.",
 		Validators: []validator.Int64{
 			int64validator.AlsoRequires(path.MatchRoot("use_ttl")),


### PR DESCRIPTION
- **NPA - 1302** -  Marked TTL as Optional + Computed for Record PTR and DTC Pool, as it was going for second terraform apply without any change in the config when the TTL value was inherited from the parent.