### PR TITLE
[DHCP][NPA - 1333] Resolve Inconsistent Offset and Address Count for IPv6 Fixed Address Template

### DIFF
--- a/internal/service/dhcp/model_ipv6fixedaddresstemplate.go
+++ b/internal/service/dhcp/model_ipv6fixedaddresstemplate.go
@@ -141,6 +141,7 @@ var Ipv6fixedaddresstemplateResourceSchemaAttributes = map[string]schema.Attribu
 	},
 	"number_of_addresses": schema.Int64Attribute{
 		Optional: true,
+		Computed: true,
 		Validators: []validator.Int64{
 			int64validator.AlsoRequires(path.MatchRoot("offset")),
 		},
@@ -148,6 +149,7 @@ var Ipv6fixedaddresstemplateResourceSchemaAttributes = map[string]schema.Attribu
 	},
 	"offset": schema.Int64Attribute{
 		Optional: true,
+		Computed: true,
 		Validators: []validator.Int64{
 			int64validator.AlsoRequires(path.MatchRoot("number_of_addresses")),
 		},


### PR DESCRIPTION
- Marked `num_of_addresses` and `offset` fields as Optional + Computed to fix the terraform drift