### PR TITLE
[Fix] [DNS] [Zone Auth] NPA- 1604 and NPA-1618

### DIFF
--- a/internal/service/dns/model_zone_auth.go
+++ b/internal/service/dns/model_zone_auth.go
@@ -604,9 +604,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional: true,
 		Computed: true,
 		Validators: []validator.List{
-			listvalidator.ConflictsWith(
-				path.MatchRoot("ns_group"),
-			),
 			listvalidator.SizeAtLeast(1),
 		},
 		MarkdownDescription: "The list of external primary servers.",
@@ -619,7 +616,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Computed: true,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
-			listvalidator.ConflictsWith(path.MatchRoot("ns_group")),
 		},
 		MarkdownDescription: "The list of external secondary servers.",
 	},
@@ -641,7 +637,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional: true,
 		Computed: true,
 		Validators: []validator.List{
-			listvalidator.ConflictsWith(path.MatchRoot("ns_group")),
 			listvalidator.SizeAtLeast(1),
 		},
 		MarkdownDescription: "The grid primary servers for this zone.",
@@ -657,9 +652,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Optional: true,
 		Computed: true,
 		Validators: []validator.List{
-			listvalidator.ConflictsWith(
-				path.MatchRoot("ns_group"),
-			),
 			listvalidator.SizeAtLeast(1),
 		},
 		MarkdownDescription: "The list with Grid members that are secondary servers for this zone.",
@@ -787,7 +779,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Computed: true,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
-			listvalidator.ConflictsWith(path.MatchRoot("ns_group")),
 		},
 		MarkdownDescription: "The list with the Microsoft DNS servers that are primary servers for the zone. Although a zone typically has just one primary name server, you can specify up to ten independent servers for a single zone.",
 	},
@@ -803,7 +794,6 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		Computed: true,
 		Validators: []validator.List{
 			listvalidator.SizeAtLeast(1),
-			listvalidator.ConflictsWith(path.MatchRoot("ns_group")),
 		},
 		MarkdownDescription: "The list with the Microsoft DNS servers that are secondary servers for the zone.",
 	},
@@ -837,10 +827,8 @@ var ZoneAuthResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The number of seconds in delay with which notify messages are sent to secondaries.",
 	},
 	"ns_group": schema.StringAttribute{
-		Optional: true,
-		Validators: []validator.String{
-			stringvalidator.ConflictsWith(path.MatchRoot("grid_primary")),
-		},
+		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "The name server group that serves DNS for this zone.",
 	},
 	"parent": schema.StringAttribute{

--- a/internal/service/dns/model_zoneauthgridsecondaries_preferred_primaries.go
+++ b/internal/service/dns/model_zoneauthgridsecondaries_preferred_primaries.go
@@ -78,7 +78,7 @@ var ZoneauthgridsecondariesPreferredPrimariesResourceSchemaAttributes = map[stri
 		Validators: []validator.String{
 			stringvalidator.OneOf("HMAC-MD5", "HMAC-SHA256"),
 		},
-		Default:             stringdefault.StaticString("HMAC-MD5.SIG-ALG.REG.INT"),
+		Default:             stringdefault.StaticString("HMAC-MD5"),
 		MarkdownDescription: "The TSIG key algorithm.",
 	},
 	"tsig_key_name": schema.StringAttribute{

--- a/internal/service/dns/zone_auth_resource.go
+++ b/internal/service/dns/zone_auth_resource.go
@@ -118,6 +118,21 @@ func (r *ZoneAuthResource) ValidateConfig(ctx context.Context, req resource.Vali
 			)
 		}
 	}
+
+	// Attribute ns_group can't be specified when any of primary or secondary server is specified
+	if !data.NsGroup.IsNull() && !data.NsGroup.IsUnknown() {
+		if (!data.GridPrimary.IsNull() && !data.GridPrimary.IsUnknown()) ||
+			(!data.ExternalPrimaries.IsNull() && !data.ExternalPrimaries.IsUnknown()) ||
+			(!data.MsPrimaries.IsNull() && !data.MsPrimaries.IsUnknown()) ||
+			(!data.GridSecondaries.IsNull() && !data.GridSecondaries.IsUnknown()) ||
+			(!data.ExternalSecondaries.IsNull() && !data.ExternalSecondaries.IsUnknown()) ||
+			(!data.MsSecondaries.IsNull() && !data.MsSecondaries.IsUnknown()) {
+			resp.Diagnostics.AddError(
+				"NS Group Not Allowed",
+				"The ns_group attribute cannot be specified when any of primary (grid_primary, external_primaries, or ms_primaries) or secondary server (grid_secondaries, external_secondaries, or ms_secondaries) is specified. Please remove the ns_group attribute or the primary/secondary server attributes.",
+			)
+		}
+	}
 }
 
 func (r *ZoneAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
- NPA - 1604 - The `ns_group` attribute cannot be specified when any of primary  or secondary server  is specified. Removed ConflictsWith validator and added a validate config to avoid multiple error messages.
- NPA- 1618 - Modified default value of `tsig_key_alg` of `preferred_primaries` under `grid_secondaries` field for `zone_auth` 