### PR TITLE
[FIX][NPA-1691]- Added validation for mgm private field in IPV6 network and IPV6 network container 

### DIFF
--- a/internal/service/ipam/ipv6network_resource.go
+++ b/internal/service/ipam/ipv6network_resource.go
@@ -631,25 +631,25 @@ func (r *Ipv6networkResource) ValidateConfig(ctx context.Context, req resource.V
 	}
 
 	// mgm_private and use_mgm_private must both be true if either one is true
-    mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
-    useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
+	mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
+	useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
 
-    mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
-    useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
+	mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
+	useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
 
-    if mgmPrivateTrue && !useMgmPrivateTrue {
-        resp.Diagnostics.AddAttributeError(
-            path.Root("use_mgm_private"),
-            "Invalid MGM Private Configuration",
-            "When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
-        )
-    } else if useMgmPrivateTrue && !mgmPrivateTrue {
-        resp.Diagnostics.AddAttributeError(
-            path.Root("mgm_private"),
-            "Invalid MGM Private Configuration",
-            "When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
-        )
-    }
+	if mgmPrivateTrue && !useMgmPrivateTrue {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("use_mgm_private"),
+			"Invalid MGM Private Configuration",
+			"When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
+		)
+	} else if useMgmPrivateTrue && !mgmPrivateTrue {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mgm_private"),
+			"Invalid MGM Private Configuration",
+			"When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
+		)
+	}
 }
 
 func (r *Ipv6networkResource) isIpv6NetworkConvertedToContainer(ctx context.Context, data *Ipv6networkModel) bool {

--- a/internal/service/ipam/ipv6network_resource.go
+++ b/internal/service/ipam/ipv6network_resource.go
@@ -629,6 +629,27 @@ func (r *Ipv6networkResource) ValidateConfig(ctx context.Context, req resource.V
 			)
 		}
 	}
+
+	// mgm_private and use_mgm_private must both be true if either one is true
+    mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
+    useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
+
+    mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
+    useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
+
+    if mgmPrivateTrue && !useMgmPrivateTrue {
+        resp.Diagnostics.AddAttributeError(
+            path.Root("use_mgm_private"),
+            "Invalid MGM Private Configuration",
+            "When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
+        )
+    } else if useMgmPrivateTrue && !mgmPrivateTrue {
+        resp.Diagnostics.AddAttributeError(
+            path.Root("mgm_private"),
+            "Invalid MGM Private Configuration",
+            "When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
+        )
+    }
 }
 
 func (r *Ipv6networkResource) isIpv6NetworkConvertedToContainer(ctx context.Context, data *Ipv6networkModel) bool {

--- a/internal/service/ipam/ipv6networkcontainer_resource.go
+++ b/internal/service/ipam/ipv6networkcontainer_resource.go
@@ -572,4 +572,25 @@ func (r *Ipv6networkcontainerResource) ValidateConfig(ctx context.Context, req r
 			)
 		}
 	}
+
+	 // mgm_private and use_mgm_private must both be true if either one is true
+	 mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
+	 useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
+ 
+	 mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
+	 useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
+ 
+	 if mgmPrivateTrue && !useMgmPrivateTrue {
+		 resp.Diagnostics.AddAttributeError(
+			 path.Root("use_mgm_private"),
+			 "Invalid MGM Private Configuration",
+			 "When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
+		 )
+	 } else if useMgmPrivateTrue && !mgmPrivateTrue {
+		 resp.Diagnostics.AddAttributeError(
+			 path.Root("mgm_private"),
+			 "Invalid MGM Private Configuration",
+			 "When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
+		 )
+	 }
 }

--- a/internal/service/ipam/ipv6networkcontainer_resource.go
+++ b/internal/service/ipam/ipv6networkcontainer_resource.go
@@ -573,24 +573,24 @@ func (r *Ipv6networkcontainerResource) ValidateConfig(ctx context.Context, req r
 		}
 	}
 
-	 // mgm_private and use_mgm_private must both be true if either one is true
-	 mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
-	 useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
- 
-	 mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
-	 useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
- 
-	 if mgmPrivateTrue && !useMgmPrivateTrue {
-		 resp.Diagnostics.AddAttributeError(
-			 path.Root("use_mgm_private"),
-			 "Invalid MGM Private Configuration",
-			 "When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
-		 )
-	 } else if useMgmPrivateTrue && !mgmPrivateTrue {
-		 resp.Diagnostics.AddAttributeError(
-			 path.Root("mgm_private"),
-			 "Invalid MGM Private Configuration",
-			 "When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
-		 )
-	 }
+	// mgm_private and use_mgm_private must both be true if either one is true
+	mgmPrivateSet := !data.MgmPrivate.IsNull() && !data.MgmPrivate.IsUnknown()
+	useMgmPrivateSet := !data.UseMgmPrivate.IsNull() && !data.UseMgmPrivate.IsUnknown()
+
+	mgmPrivateTrue := mgmPrivateSet && data.MgmPrivate.ValueBool()
+	useMgmPrivateTrue := useMgmPrivateSet && data.UseMgmPrivate.ValueBool()
+
+	if mgmPrivateTrue && !useMgmPrivateTrue {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("use_mgm_private"),
+			"Invalid MGM Private Configuration",
+			"When 'mgm_private' is set to true, 'use_mgm_private' must also be set to true.",
+		)
+	} else if useMgmPrivateTrue && !mgmPrivateTrue {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mgm_private"),
+			"Invalid MGM Private Configuration",
+			"When 'use_mgm_private' is set to true, 'mgm_private' must also be set to true.",
+		)
+	}
 }


### PR DESCRIPTION
Validation : 
mgm_private and use_mgm_private both must be true if either one is true