### PR TITLE
[NPA-1728] [IPAM] Normalize `ddns_dns_view` field to align with backend response in Network View

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/infobloxopen/infoblox-nios-go-client v0.1.2-0.20260327084847-be0440724a6e
-	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
 )
 
 require (
@@ -74,6 +73,7 @@ require (
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -801,7 +801,7 @@ func GetOptionName[T any](option T) *string {
 	val := reflect.ValueOf(option)
 
 	// Handle pointer types by dereferencing
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}
@@ -815,7 +815,7 @@ func GetOptionName[T any](option T) *string {
 	}
 
 	// If Name is a pointer to string
-	if nameField.Kind() == reflect.Ptr {
+	if nameField.Kind() == reflect.Pointer {
 		if nameField.IsNil() {
 			return nil
 		}
@@ -838,7 +838,7 @@ func GetOptionUseFlag[T any](option T) *bool {
 	val := reflect.ValueOf(option)
 
 	// Handle pointer types by dereferencing
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}
@@ -852,7 +852,7 @@ func GetOptionUseFlag[T any](option T) *bool {
 	}
 
 	// If UseOption is a pointer to bool
-	if useField.Kind() == reflect.Ptr {
+	if useField.Kind() == reflect.Pointer {
 		if useField.IsNil() {
 			return nil
 		}

--- a/internal/service/ipam/model_networkview.go
+++ b/internal/service/ipam/model_networkview.go
@@ -258,8 +258,6 @@ func (m *NetworkviewModel) Flatten(ctx context.Context, from *ipam.Networkview, 
 	m.CloudInfo = FlattenNetworkviewCloudInfo(ctx, from.CloudInfo, diags)
 	m.Comment = flex.FlattenStringPointer(from.Comment)
 	m.DdnsDnsView = flex.FlattenStringPointer(from.DdnsDnsView)
-	// NIOS qualifies ddns_dns_view by appending ".<network_view_name>" (e.g. "default" -> "default.my_nv").
-	// Normalize by stripping the suffix so state matches the user-provided config value.
 	if !m.DdnsDnsView.IsNull() && from.Name != nil {
 		if val := m.DdnsDnsView.ValueString(); strings.HasSuffix(val, "."+*from.Name) {
 			m.DdnsDnsView = types.StringValue(strings.TrimSuffix(val, "."+*from.Name))

--- a/internal/service/ipam/model_networkview.go
+++ b/internal/service/ipam/model_networkview.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -257,6 +258,13 @@ func (m *NetworkviewModel) Flatten(ctx context.Context, from *ipam.Networkview, 
 	m.CloudInfo = FlattenNetworkviewCloudInfo(ctx, from.CloudInfo, diags)
 	m.Comment = flex.FlattenStringPointer(from.Comment)
 	m.DdnsDnsView = flex.FlattenStringPointer(from.DdnsDnsView)
+	// NIOS qualifies ddns_dns_view by appending ".<network_view_name>" (e.g. "default" -> "default.my_nv").
+	// Normalize by stripping the suffix so state matches the user-provided config value.
+	if !m.DdnsDnsView.IsNull() && from.Name != nil {
+		if val := m.DdnsDnsView.ValueString(); strings.HasSuffix(val, "."+*from.Name) {
+			m.DdnsDnsView = types.StringValue(strings.TrimSuffix(val, "."+*from.Name))
+		}
+	}
 	m.DdnsZonePrimaries = flex.FlattenFrameworkListNestedBlock(ctx, from.DdnsZonePrimaries, NetworkviewDdnsZonePrimariesAttrTypes, diags, FlattenNetworkviewDdnsZonePrimaries)
 	m.ExtAttrs = FlattenExtAttrs(ctx, m.ExtAttrs, from.ExtAttrs, diags)
 	m.FederatedRealms = flex.FlattenFrameworkListNestedBlock(ctx, from.FederatedRealms, NetworkviewFederatedRealmsAttrTypes, diags, FlattenNetworkviewFederatedRealms)

--- a/internal/service/ipam/model_networkview.go
+++ b/internal/service/ipam/model_networkview.go
@@ -257,12 +257,18 @@ func (m *NetworkviewModel) Flatten(ctx context.Context, from *ipam.Networkview, 
 	m.AssociatedMembers = flex.FlattenFrameworkListNestedBlock(ctx, from.AssociatedMembers, NetworkviewAssociatedMembersAttrTypes, diags, FlattenNetworkviewAssociatedMembers)
 	m.CloudInfo = FlattenNetworkviewCloudInfo(ctx, from.CloudInfo, diags)
 	m.Comment = flex.FlattenStringPointer(from.Comment)
+
+	configDdnsDnsView := m.DdnsDnsView
 	m.DdnsDnsView = flex.FlattenStringPointer(from.DdnsDnsView)
 	if !m.DdnsDnsView.IsNull() && from.Name != nil {
 		if val := m.DdnsDnsView.ValueString(); strings.HasSuffix(val, "."+*from.Name) {
-			m.DdnsDnsView = types.StringValue(strings.TrimSuffix(val, "."+*from.Name))
+			stripped := strings.TrimSuffix(val, "."+*from.Name)
+			if configDdnsDnsView.IsNull() || configDdnsDnsView.IsUnknown() || configDdnsDnsView.ValueString() == stripped {
+				m.DdnsDnsView = types.StringValue(stripped)
+			}
 		}
 	}
+	
 	m.DdnsZonePrimaries = flex.FlattenFrameworkListNestedBlock(ctx, from.DdnsZonePrimaries, NetworkviewDdnsZonePrimariesAttrTypes, diags, FlattenNetworkviewDdnsZonePrimaries)
 	m.ExtAttrs = FlattenExtAttrs(ctx, m.ExtAttrs, from.ExtAttrs, diags)
 	m.FederatedRealms = flex.FlattenFrameworkListNestedBlock(ctx, from.FederatedRealms, NetworkviewFederatedRealmsAttrTypes, diags, FlattenNetworkviewFederatedRealms)

--- a/internal/service/ipam/networkview_resource_test.go
+++ b/internal/service/ipam/networkview_resource_test.go
@@ -157,7 +157,7 @@ func TestAccNetworkviewResource_DdnsDnsView(t *testing.T) {
 				Config: testAccNetworkviewDdnsDnsView(name, "null"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkviewExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "ddns_dns_view", DdnsDnsView),
+					resource.TestCheckResourceAttr(resourceName, "ddns_dns_view", "default"),
 				),
 			},
 			// Update and Read

--- a/internal/types/unordered_list.go
+++ b/internal/types/unordered_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 var UnorderedListOfStringType = UnorderedList{basetypes.ListType{ElemType: basetypes.StringType{}}}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -378,7 +378,7 @@ func ExtractResourceRef(ref string) string {
 
 func FindModelFieldByTFSdkTag(model any, tagName string) (string, bool) {
 	modelType := reflect.TypeOf(model)
-	if modelType.Kind() == reflect.Ptr {
+	if modelType.Kind() == reflect.Pointer {
 		modelType = modelType.Elem()
 	}
 


### PR DESCRIPTION
Issue : 
nios_ipam_network_view: ddns_dns_view causes "inconsistent result after apply" — provider doesn't normalize NIOS response

Solution :
Modify Flatten of Network to normalize  `ddns_dns_view` response. 


Also , Fixed Linter issues corresponding to govet ! 