### PR TITLE
Update provider to allow use of dummy credentials

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -111,9 +111,9 @@ func (p *NIOSProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	err := checkAndCreatePreRequisites(ctx, client)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Failed to ensure Terraform extensible attribute exists",
-			err.Error(),
+		resp.Diagnostics.AddWarning(
+			"Unable to verify Terraform extensible attribute during provider configuration",
+			fmt.Sprintf("The provider could not ensure the %q extensible attribute exists while configuring the client. Terraform can still continue when no nios-managed resources or data sources are used, but NIOS operations may fail later: %s", terraformInternalIDEA, err),
 		)
 	}
 	resp.DataSourceData = client


### PR DESCRIPTION
This PR allows the use of dummy credentials in the Infoblox NIOS provider by changing its behaviour when extensible attributes can't be verified during provider initialisation.

This means that Terraform configurations which contain the NIOS provider but do not necessarily manage any NIOS resources or data sources (for example configurations deployed to multiple environments which do not all have network connectivity to an Infoblox instance) can function without authenticating to Infoblox.