### PR TITLE
NPA-1779: Added fix for already exists error case in retry handling

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -136,11 +136,8 @@ func IsNetworkError(err error) bool {
 	return false
 }
 
-// IsAlreadyExistsErr checks if the error indicates that the resource already exists.
-func IsAlreadyExistsErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := strings.ToLower(err.Error())
-	return strings.Contains(errStr, "already exists") || strings.Contains(errStr, "conflict")
+// IsAlreadyExistsErr is currently disabled and always returns false.
+// Later, when retryable errors are added, we should add proper NIOS error string matching here for resource already exists cases.
+func IsAlreadyExistsErr(_err error) bool {
+	return false
 }


### PR DESCRIPTION
`IsAlreadyExistsErr` is currently disabled (always returns false)

Reason: Matching on "conflict" and "already exists" strings is not reliable, since NIOS does not use a single error constant and status code is always 400 in these cases. These substrings alone (or in combination) are not sufficient to accurately detect when a resource already exists.

Later, when we add retryable errors, we can revisit this and add proper NIOS error string matching for resource existence. Another option could be to check the error substring and then do a GET call to confirm the object exists.

For now, this avoids false positives and keeps error handling predictable.