### PR TITLE
[FIX[[NPA-1834]-Marked the member_service_communication as optional

### DIFF
--- a/docs/data-sources/grid_member.md
+++ b/docs/data-sources/grid_member.md
@@ -82,6 +82,7 @@ Optional:
 - `lom_network_config` (Attributes List) The Network configurations for LOM. (see [below for nested schema](#nestedatt--result--lom_network_config))
 - `lom_users` (Attributes List) The list of LOM users. (see [below for nested schema](#nestedatt--result--lom_users))
 - `master_candidate` (Boolean) Determines if a Grid member is a Grid Master Candidate or not. This flag enables the Grid member to assume the role of the Grid Master as a disaster recovery measure.
+- `member_service_communication` (Attributes List) Configure communication type for various services. (see [below for nested schema](#nestedatt--result--member_service_communication))
 - `mgmt_port_setting` (Attributes) Settings for the member MGMT port. (see [below for nested schema](#nestedatt--result--mgmt_port_setting))
 - `nat_setting` (Attributes) NAT settings for the member. (see [below for nested schema](#nestedatt--result--nat_setting))
 - `node_info` (Attributes List) The node information list with detailed status report on the operations of the Grid Member, mgmt_port_setting must be enabled when configuring the MGMT Port using the node_info field. (see [below for nested schema](#nestedatt--result--node_info))
@@ -137,7 +138,6 @@ Read-Only:
 - `active_position` (String) The active server of a Grid member.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object, including default and internal attributes.
 - `is_dscp_capable` (Boolean) Determines if a Grid member supports DSCP (Differentiated Services Code Point).
-- `member_service_communication` (Attributes List) Configure communication type for various services. (see [below for nested schema](#nestedatt--result--member_service_communication))
 - `mmdb_ea_build_time` (Number) Extensible attributes Topology database build time.
 - `mmdb_geoip_build_time` (Number) GeoIP Topology database build time.
 - `ref` (String) The reference to the object.
@@ -409,6 +409,19 @@ Optional:
 - `comment` (String) The descriptive comment for the LOM user.
 - `disable` (Boolean) Determines whether the LOM user is disabled.
 - `role` (String) The LOM user role which specifies the list of actions that are allowed for the user.
+
+
+<a id="nestedatt--result--member_service_communication"></a>
+### Nested Schema for `result.member_service_communication`
+
+Optional:
+
+- `service` (String) The service for a Grid member.
+- `type` (String) Communication type.
+
+Read-Only:
+
+- `option` (String) The option for communication type.
 
 
 <a id="nestedatt--result--mgmt_port_setting"></a>
@@ -899,16 +912,6 @@ Optional:
 - `subnet_mask` (String) The subnet mask for the Grid Member.
 - `use_dscp` (Boolean) Use flag for: dscp
 - `vlan_id` (Number) The identifier for the VLAN. Valid values are from 1 to 4096.
-
-
-<a id="nestedatt--result--member_service_communication"></a>
-### Nested Schema for `result.member_service_communication`
-
-Read-Only:
-
-- `option` (String) The option for communication type.
-- `service` (String) The service for a Grid member.
-- `type` (String) Communication type.
 
 
 <a id="nestedatt--result--service_status"></a>

--- a/docs/resources/grid_member.md
+++ b/docs/resources/grid_member.md
@@ -130,6 +130,7 @@ resource "nios_grid_member" "example_member_with_additional_fields" {
 - `lom_network_config` (Attributes List) The Network configurations for LOM. (see [below for nested schema](#nestedatt--lom_network_config))
 - `lom_users` (Attributes List) The list of LOM users. (see [below for nested schema](#nestedatt--lom_users))
 - `master_candidate` (Boolean) Determines if a Grid member is a Grid Master Candidate or not. This flag enables the Grid member to assume the role of the Grid Master as a disaster recovery measure.
+- `member_service_communication` (Attributes List) Configure communication type for various services. (see [below for nested schema](#nestedatt--member_service_communication))
 - `mgmt_port_setting` (Attributes) Settings for the member MGMT port. (see [below for nested schema](#nestedatt--mgmt_port_setting))
 - `nat_setting` (Attributes) NAT settings for the member. (see [below for nested schema](#nestedatt--nat_setting))
 - `node_info` (Attributes List) The node information list with detailed status report on the operations of the Grid Member, mgmt_port_setting must be enabled when configuring the MGMT Port using the node_info field. (see [below for nested schema](#nestedatt--node_info))
@@ -185,7 +186,6 @@ resource "nios_grid_member" "example_member_with_additional_fields" {
 - `active_position` (String) The active server of a Grid member.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object, including default and internal attributes.
 - `is_dscp_capable` (Boolean) Determines if a Grid member supports DSCP (Differentiated Services Code Point).
-- `member_service_communication` (Attributes List) Configure communication type for various services. (see [below for nested schema](#nestedatt--member_service_communication))
 - `mmdb_ea_build_time` (Number) Extensible attributes Topology database build time.
 - `mmdb_geoip_build_time` (Number) GeoIP Topology database build time.
 - `ref` (String) The reference to the object.
@@ -457,6 +457,19 @@ Optional:
 - `comment` (String) The descriptive comment for the LOM user.
 - `disable` (Boolean) Determines whether the LOM user is disabled.
 - `role` (String) The LOM user role which specifies the list of actions that are allowed for the user.
+
+
+<a id="nestedatt--member_service_communication"></a>
+### Nested Schema for `member_service_communication`
+
+Optional:
+
+- `service` (String) The service for a Grid member.
+- `type` (String) Communication type.
+
+Read-Only:
+
+- `option` (String) The option for communication type.
 
 
 <a id="nestedatt--mgmt_port_setting"></a>
@@ -947,16 +960,6 @@ Optional:
 - `subnet_mask` (String) The subnet mask for the Grid Member.
 - `use_dscp` (Boolean) Use flag for: dscp
 - `vlan_id` (Number) The identifier for the VLAN. Valid values are from 1 to 4096.
-
-
-<a id="nestedatt--member_service_communication"></a>
-### Nested Schema for `member_service_communication`
-
-Read-Only:
-
-- `option` (String) The option for communication type.
-- `service` (String) The service for a Grid member.
-- `type` (String) Communication type.
 
 
 <a id="nestedatt--service_status"></a>

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -146,7 +146,7 @@ func (r *MemberResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	res := apiRes.CreateMemberResponseAsObject.GetResult()
 
-	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() || (!data.TrafficCaptureAuthDnsSetting.IsUnknown() && !data.TrafficCaptureAuthDnsSetting.IsNull()) {
+	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() || (!data.TrafficCaptureAuthDnsSetting.IsUnknown() && !data.TrafficCaptureAuthDnsSetting.IsNull()) || (!data.MemberServiceCommunication.IsUnknown() && !data.MemberServiceCommunication.IsNull()) || (!data.SyslogProxySetting.IsUnknown() && !data.SyslogProxySetting.IsNull()) {
 		apiRes2, _, err2 := r.client.GridAPI.
 			MemberAPI.
 			Update(ctx, utils.ExtractResourceRef(*res.Ref)).

--- a/internal/service/grid/model_member.go
+++ b/internal/service/grid/model_member.go
@@ -1042,7 +1042,7 @@ func (m *MemberModel) Flatten(ctx context.Context, from *grid.Member, diags *dia
 	m.MasterCandidate = types.BoolPointerValue(from.MasterCandidate)
 	planMsc := m.MemberServiceCommunication
 	listVal := flex.FlattenFrameworkListNestedBlock(ctx, from.MemberServiceCommunication, MemberMemberServiceCommunicationAttrTypes, diags, FlattenMemberMemberServiceCommunication)
-	if !planMsc.ListValue.IsUnknown() && !planMsc.ListValue.IsNull() {
+	if !planMsc.IsUnknown() && !planMsc.IsNull() {
 		reOrderedList, reorderDiags := utils.ReorderAndFilterNestedListResponse(ctx, planMsc.ListValue, listVal, "service")
 		if !reorderDiags.HasError() {
 			listVal = reOrderedList.(basetypes.ListValue)

--- a/internal/service/grid/model_member.go
+++ b/internal/service/grid/model_member.go
@@ -476,6 +476,7 @@ var MemberResourceSchemaAttributes = map[string]schema.Attribute{
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: MemberMemberServiceCommunicationResourceSchemaAttributes,
 		},
+		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "Configure communication type for various services.",
 	},
@@ -898,7 +899,6 @@ func (m *MemberModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 		LomNetworkConfig:                flex.ExpandFrameworkListNestedBlock(ctx, m.LomNetworkConfig, diags, ExpandMemberLomNetworkConfig),
 		LomUsers:                        flex.ExpandFrameworkListNestedBlock(ctx, m.LomUsers, diags, ExpandMemberLomUsers),
 		MasterCandidate:                 flex.ExpandBoolPointer(m.MasterCandidate),
-		MemberServiceCommunication:      flex.ExpandFrameworkListNestedBlockEmptyAsNil(ctx, m.MemberServiceCommunication, diags, ExpandMemberMemberServiceCommunication),
 		MgmtPortSetting:                 ExpandMemberMgmtPortSetting(ctx, m.MgmtPortSetting, diags),
 		NatSetting:                      ExpandMemberNatSetting(ctx, m.NatSetting, diags),
 		NodeInfo:                        flex.ExpandFrameworkListNestedBlock(ctx, m.NodeInfo, diags, ExpandMemberNodeInfo),
@@ -951,6 +951,7 @@ func (m *MemberModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 
 	if !isCreate {
 		to.PreProvisioning = ExpandMemberPreProvisioning(ctx, m.PreProvisioning, diags)
+		to.MemberServiceCommunication = flex.ExpandFrameworkListNestedBlockEmptyAsNil(ctx, m.MemberServiceCommunication, diags, ExpandMemberMemberServiceCommunication)
 	}
 
 	if m.ConfigureCspMemberSetting.ValueBool() {

--- a/internal/service/grid/model_member.go
+++ b/internal/service/grid/model_member.go
@@ -26,98 +26,99 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-nios/internal/flex"
 	importmod "github.com/infobloxopen/terraform-provider-nios/internal/planmodifiers/import"
+	internaltypes "github.com/infobloxopen/terraform-provider-nios/internal/types"
 	"github.com/infobloxopen/terraform-provider-nios/internal/utils"
 	customvalidator "github.com/infobloxopen/terraform-provider-nios/internal/validator"
 )
 
 type MemberModel struct {
-	Ref                             types.String `tfsdk:"ref"`
-	ActivePosition                  types.String `tfsdk:"active_position"`
-	AdditionalIpList                types.List   `tfsdk:"additional_ip_list"`
-	AutomatedTrafficCaptureSetting  types.Object `tfsdk:"automated_traffic_capture_setting"`
-	BgpAs                           types.List   `tfsdk:"bgp_as"`
-	Comment                         types.String `tfsdk:"comment"`
-	ConfigAddrType                  types.String `tfsdk:"config_addr_type"`
-	CspAccessKey                    types.List   `tfsdk:"csp_access_key"`
-	CspMemberSetting                types.Object `tfsdk:"csp_member_setting"`
-	ConfigureCspMemberSetting       types.Bool   `tfsdk:"configure_csp_member_setting"`
-	DnsResolverSetting              types.Object `tfsdk:"dns_resolver_setting"`
-	GridLevelDnsResolverSetting     types.Object `tfsdk:"grid_level_dns_resolver_setting"`
-	Dscp                            types.Int64  `tfsdk:"dscp"`
-	EmailSetting                    types.Object `tfsdk:"email_setting"`
-	EnableHa                        types.Bool   `tfsdk:"enable_ha"`
-	EnableLom                       types.Bool   `tfsdk:"enable_lom"`
-	EnableMemberRedirect            types.Bool   `tfsdk:"enable_member_redirect"`
-	EnableRoApiAccess               types.Bool   `tfsdk:"enable_ro_api_access"`
-	ExtAttrs                        types.Map    `tfsdk:"extattrs"`
-	ExtAttrsAll                     types.Map    `tfsdk:"extattrs_all"`
-	ExternalSyslogBackupServers     types.List   `tfsdk:"external_syslog_backup_servers"`
-	ExternalSyslogServerEnable      types.Bool   `tfsdk:"external_syslog_server_enable"`
-	HaCloudPlatform                 types.String `tfsdk:"ha_cloud_platform"`
-	HaOnCloud                       types.Bool   `tfsdk:"ha_on_cloud"`
-	HostName                        types.String `tfsdk:"host_name"`
-	Ipv6Setting                     types.Object `tfsdk:"ipv6_setting"`
-	Ipv6StaticRoutes                types.List   `tfsdk:"ipv6_static_routes"`
-	IsDscpCapable                   types.Bool   `tfsdk:"is_dscp_capable"`
-	Lan2Enabled                     types.Bool   `tfsdk:"lan2_enabled"`
-	Lan2PortSetting                 types.Object `tfsdk:"lan2_port_setting"`
-	LomNetworkConfig                types.List   `tfsdk:"lom_network_config"`
-	LomUsers                        types.List   `tfsdk:"lom_users"`
-	MasterCandidate                 types.Bool   `tfsdk:"master_candidate"`
-	MemberServiceCommunication      types.List   `tfsdk:"member_service_communication"`
-	MgmtPortSetting                 types.Object `tfsdk:"mgmt_port_setting"`
-	MmdbEaBuildTime                 types.Int64  `tfsdk:"mmdb_ea_build_time"`
-	MmdbGeoipBuildTime              types.Int64  `tfsdk:"mmdb_geoip_build_time"`
-	NatSetting                      types.Object `tfsdk:"nat_setting"`
-	NodeInfo                        types.List   `tfsdk:"node_info"`
-	NtpSetting                      types.Object `tfsdk:"ntp_setting"`
-	OspfList                        types.List   `tfsdk:"ospf_list"`
-	PassiveHaArpEnabled             types.Bool   `tfsdk:"passive_ha_arp_enabled"`
-	Platform                        types.String `tfsdk:"platform"`
-	PreProvisioning                 types.Object `tfsdk:"pre_provisioning"`
-	PreserveIfOwnsDelegation        types.Bool   `tfsdk:"preserve_if_owns_delegation"`
-	RemoteConsoleAccessEnable       types.Bool   `tfsdk:"remote_console_access_enable"`
-	RouterId                        types.Int64  `tfsdk:"router_id"`
-	ServiceStatus                   types.List   `tfsdk:"service_status"`
-	ServiceTypeConfiguration        types.String `tfsdk:"service_type_configuration"`
-	SnmpSetting                     types.Object `tfsdk:"snmp_setting"`
-	StaticRoutes                    types.List   `tfsdk:"static_routes"`
-	SupportAccessEnable             types.Bool   `tfsdk:"support_access_enable"`
-	SupportAccessInfo               types.String `tfsdk:"support_access_info"`
-	SyslogProxySetting              types.Object `tfsdk:"syslog_proxy_setting"`
-	SyslogServers                   types.List   `tfsdk:"syslog_servers"`
-	SyslogSize                      types.Int64  `tfsdk:"syslog_size"`
-	ThresholdTraps                  types.List   `tfsdk:"threshold_traps"`
-	TimeZone                        types.String `tfsdk:"time_zone"`
-	TrafficCaptureAuthDnsSetting    types.Object `tfsdk:"traffic_capture_auth_dns_setting"`
-	TrafficCaptureChrSetting        types.Object `tfsdk:"traffic_capture_chr_setting"`
-	TrafficCaptureQpsSetting        types.Object `tfsdk:"traffic_capture_qps_setting"`
-	TrafficCaptureRecDnsSetting     types.Object `tfsdk:"traffic_capture_rec_dns_setting"`
-	TrafficCaptureRecQueriesSetting types.Object `tfsdk:"traffic_capture_rec_queries_setting"`
-	TrapNotifications               types.List   `tfsdk:"trap_notifications"`
-	UpgradeGroup                    types.String `tfsdk:"upgrade_group"`
-	UseAutomatedTrafficCapture      types.Bool   `tfsdk:"use_automated_traffic_capture"`
-	UseDnsResolverSetting           types.Bool   `tfsdk:"use_dns_resolver_setting"`
-	UseDscp                         types.Bool   `tfsdk:"use_dscp"`
-	UseEmailSetting                 types.Bool   `tfsdk:"use_email_setting"`
-	UseEnableLom                    types.Bool   `tfsdk:"use_enable_lom"`
-	UseEnableMemberRedirect         types.Bool   `tfsdk:"use_enable_member_redirect"`
-	UseExternalSyslogBackupServers  types.Bool   `tfsdk:"use_external_syslog_backup_servers"`
-	UseRemoteConsoleAccessEnable    types.Bool   `tfsdk:"use_remote_console_access_enable"`
-	UseSnmpSetting                  types.Bool   `tfsdk:"use_snmp_setting"`
-	UseSupportAccessEnable          types.Bool   `tfsdk:"use_support_access_enable"`
-	UseSyslogProxySetting           types.Bool   `tfsdk:"use_syslog_proxy_setting"`
-	UseThresholdTraps               types.Bool   `tfsdk:"use_threshold_traps"`
-	UseTimeZone                     types.Bool   `tfsdk:"use_time_zone"`
-	UseTrafficCaptureAuthDns        types.Bool   `tfsdk:"use_traffic_capture_auth_dns"`
-	UseTrafficCaptureChr            types.Bool   `tfsdk:"use_traffic_capture_chr"`
-	UseTrafficCaptureQps            types.Bool   `tfsdk:"use_traffic_capture_qps"`
-	UseTrafficCaptureRecDns         types.Bool   `tfsdk:"use_traffic_capture_rec_dns"`
-	UseTrafficCaptureRecQueries     types.Bool   `tfsdk:"use_traffic_capture_rec_queries"`
-	UseTrapNotifications            types.Bool   `tfsdk:"use_trap_notifications"`
-	UseV4Vrrp                       types.Bool   `tfsdk:"use_v4_vrrp"`
-	VipSetting                      types.Object `tfsdk:"vip_setting"`
-	VpnMtu                          types.Int64  `tfsdk:"vpn_mtu"`
+	Ref                             types.String                     `tfsdk:"ref"`
+	ActivePosition                  types.String                     `tfsdk:"active_position"`
+	AdditionalIpList                types.List                       `tfsdk:"additional_ip_list"`
+	AutomatedTrafficCaptureSetting  types.Object                     `tfsdk:"automated_traffic_capture_setting"`
+	BgpAs                           types.List                       `tfsdk:"bgp_as"`
+	Comment                         types.String                     `tfsdk:"comment"`
+	ConfigAddrType                  types.String                     `tfsdk:"config_addr_type"`
+	CspAccessKey                    types.List                       `tfsdk:"csp_access_key"`
+	CspMemberSetting                types.Object                     `tfsdk:"csp_member_setting"`
+	ConfigureCspMemberSetting       types.Bool                       `tfsdk:"configure_csp_member_setting"`
+	DnsResolverSetting              types.Object                     `tfsdk:"dns_resolver_setting"`
+	GridLevelDnsResolverSetting     types.Object                     `tfsdk:"grid_level_dns_resolver_setting"`
+	Dscp                            types.Int64                      `tfsdk:"dscp"`
+	EmailSetting                    types.Object                     `tfsdk:"email_setting"`
+	EnableHa                        types.Bool                       `tfsdk:"enable_ha"`
+	EnableLom                       types.Bool                       `tfsdk:"enable_lom"`
+	EnableMemberRedirect            types.Bool                       `tfsdk:"enable_member_redirect"`
+	EnableRoApiAccess               types.Bool                       `tfsdk:"enable_ro_api_access"`
+	ExtAttrs                        types.Map                        `tfsdk:"extattrs"`
+	ExtAttrsAll                     types.Map                        `tfsdk:"extattrs_all"`
+	ExternalSyslogBackupServers     types.List                       `tfsdk:"external_syslog_backup_servers"`
+	ExternalSyslogServerEnable      types.Bool                       `tfsdk:"external_syslog_server_enable"`
+	HaCloudPlatform                 types.String                     `tfsdk:"ha_cloud_platform"`
+	HaOnCloud                       types.Bool                       `tfsdk:"ha_on_cloud"`
+	HostName                        types.String                     `tfsdk:"host_name"`
+	Ipv6Setting                     types.Object                     `tfsdk:"ipv6_setting"`
+	Ipv6StaticRoutes                types.List                       `tfsdk:"ipv6_static_routes"`
+	IsDscpCapable                   types.Bool                       `tfsdk:"is_dscp_capable"`
+	Lan2Enabled                     types.Bool                       `tfsdk:"lan2_enabled"`
+	Lan2PortSetting                 types.Object                     `tfsdk:"lan2_port_setting"`
+	LomNetworkConfig                types.List                       `tfsdk:"lom_network_config"`
+	LomUsers                        types.List                       `tfsdk:"lom_users"`
+	MasterCandidate                 types.Bool                       `tfsdk:"master_candidate"`
+	MemberServiceCommunication      internaltypes.UnorderedListValue `tfsdk:"member_service_communication"`
+	MgmtPortSetting                 types.Object                     `tfsdk:"mgmt_port_setting"`
+	MmdbEaBuildTime                 types.Int64                      `tfsdk:"mmdb_ea_build_time"`
+	MmdbGeoipBuildTime              types.Int64                      `tfsdk:"mmdb_geoip_build_time"`
+	NatSetting                      types.Object                     `tfsdk:"nat_setting"`
+	NodeInfo                        types.List                       `tfsdk:"node_info"`
+	NtpSetting                      types.Object                     `tfsdk:"ntp_setting"`
+	OspfList                        types.List                       `tfsdk:"ospf_list"`
+	PassiveHaArpEnabled             types.Bool                       `tfsdk:"passive_ha_arp_enabled"`
+	Platform                        types.String                     `tfsdk:"platform"`
+	PreProvisioning                 types.Object                     `tfsdk:"pre_provisioning"`
+	PreserveIfOwnsDelegation        types.Bool                       `tfsdk:"preserve_if_owns_delegation"`
+	RemoteConsoleAccessEnable       types.Bool                       `tfsdk:"remote_console_access_enable"`
+	RouterId                        types.Int64                      `tfsdk:"router_id"`
+	ServiceStatus                   types.List                       `tfsdk:"service_status"`
+	ServiceTypeConfiguration        types.String                     `tfsdk:"service_type_configuration"`
+	SnmpSetting                     types.Object                     `tfsdk:"snmp_setting"`
+	StaticRoutes                    types.List                       `tfsdk:"static_routes"`
+	SupportAccessEnable             types.Bool                       `tfsdk:"support_access_enable"`
+	SupportAccessInfo               types.String                     `tfsdk:"support_access_info"`
+	SyslogProxySetting              types.Object                     `tfsdk:"syslog_proxy_setting"`
+	SyslogServers                   types.List                       `tfsdk:"syslog_servers"`
+	SyslogSize                      types.Int64                      `tfsdk:"syslog_size"`
+	ThresholdTraps                  types.List                       `tfsdk:"threshold_traps"`
+	TimeZone                        types.String                     `tfsdk:"time_zone"`
+	TrafficCaptureAuthDnsSetting    types.Object                     `tfsdk:"traffic_capture_auth_dns_setting"`
+	TrafficCaptureChrSetting        types.Object                     `tfsdk:"traffic_capture_chr_setting"`
+	TrafficCaptureQpsSetting        types.Object                     `tfsdk:"traffic_capture_qps_setting"`
+	TrafficCaptureRecDnsSetting     types.Object                     `tfsdk:"traffic_capture_rec_dns_setting"`
+	TrafficCaptureRecQueriesSetting types.Object                     `tfsdk:"traffic_capture_rec_queries_setting"`
+	TrapNotifications               types.List                       `tfsdk:"trap_notifications"`
+	UpgradeGroup                    types.String                     `tfsdk:"upgrade_group"`
+	UseAutomatedTrafficCapture      types.Bool                       `tfsdk:"use_automated_traffic_capture"`
+	UseDnsResolverSetting           types.Bool                       `tfsdk:"use_dns_resolver_setting"`
+	UseDscp                         types.Bool                       `tfsdk:"use_dscp"`
+	UseEmailSetting                 types.Bool                       `tfsdk:"use_email_setting"`
+	UseEnableLom                    types.Bool                       `tfsdk:"use_enable_lom"`
+	UseEnableMemberRedirect         types.Bool                       `tfsdk:"use_enable_member_redirect"`
+	UseExternalSyslogBackupServers  types.Bool                       `tfsdk:"use_external_syslog_backup_servers"`
+	UseRemoteConsoleAccessEnable    types.Bool                       `tfsdk:"use_remote_console_access_enable"`
+	UseSnmpSetting                  types.Bool                       `tfsdk:"use_snmp_setting"`
+	UseSupportAccessEnable          types.Bool                       `tfsdk:"use_support_access_enable"`
+	UseSyslogProxySetting           types.Bool                       `tfsdk:"use_syslog_proxy_setting"`
+	UseThresholdTraps               types.Bool                       `tfsdk:"use_threshold_traps"`
+	UseTimeZone                     types.Bool                       `tfsdk:"use_time_zone"`
+	UseTrafficCaptureAuthDns        types.Bool                       `tfsdk:"use_traffic_capture_auth_dns"`
+	UseTrafficCaptureChr            types.Bool                       `tfsdk:"use_traffic_capture_chr"`
+	UseTrafficCaptureQps            types.Bool                       `tfsdk:"use_traffic_capture_qps"`
+	UseTrafficCaptureRecDns         types.Bool                       `tfsdk:"use_traffic_capture_rec_dns"`
+	UseTrafficCaptureRecQueries     types.Bool                       `tfsdk:"use_traffic_capture_rec_queries"`
+	UseTrapNotifications            types.Bool                       `tfsdk:"use_trap_notifications"`
+	UseV4Vrrp                       types.Bool                       `tfsdk:"use_v4_vrrp"`
+	VipSetting                      types.Object                     `tfsdk:"vip_setting"`
+	VpnMtu                          types.Int64                      `tfsdk:"vpn_mtu"`
 }
 
 var MemberAttrTypes = map[string]attr.Type{
@@ -154,7 +155,7 @@ var MemberAttrTypes = map[string]attr.Type{
 	"lom_network_config":                  types.ListType{ElemType: types.ObjectType{AttrTypes: MemberLomNetworkConfigAttrTypes}},
 	"lom_users":                           types.ListType{ElemType: types.ObjectType{AttrTypes: MemberLomUsersAttrTypes}},
 	"master_candidate":                    types.BoolType,
-	"member_service_communication":        types.ListType{ElemType: types.ObjectType{AttrTypes: MemberMemberServiceCommunicationAttrTypes}},
+	"member_service_communication":        internaltypes.NewUnorderedList(types.ObjectType{AttrTypes: MemberMemberServiceCommunicationAttrTypes}),
 	"mgmt_port_setting":                   types.ObjectType{AttrTypes: MemberMgmtPortSettingAttrTypes},
 	"mmdb_ea_build_time":                  types.Int64Type,
 	"mmdb_geoip_build_time":               types.Int64Type,
@@ -473,6 +474,7 @@ var MemberResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "Determines if a Grid member is a Grid Master Candidate or not. This flag enables the Grid member to assume the role of the Grid Master as a disaster recovery measure.",
 	},
 	"member_service_communication": schema.ListNestedAttribute{
+		CustomType: internaltypes.NewUnorderedList(types.ObjectType{AttrTypes: MemberMemberServiceCommunicationAttrTypes}),
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: MemberMemberServiceCommunicationResourceSchemaAttributes,
 		},
@@ -1038,7 +1040,15 @@ func (m *MemberModel) Flatten(ctx context.Context, from *grid.Member, diags *dia
 		}
 	}
 	m.MasterCandidate = types.BoolPointerValue(from.MasterCandidate)
-	m.MemberServiceCommunication = flex.FlattenFrameworkListNestedBlock(ctx, from.MemberServiceCommunication, MemberMemberServiceCommunicationAttrTypes, diags, FlattenMemberMemberServiceCommunication)
+	planMsc := m.MemberServiceCommunication
+	listVal := flex.FlattenFrameworkListNestedBlock(ctx, from.MemberServiceCommunication, MemberMemberServiceCommunicationAttrTypes, diags, FlattenMemberMemberServiceCommunication)
+	if !planMsc.ListValue.IsUnknown() && !planMsc.ListValue.IsNull() {
+		reOrderedList, reorderDiags := utils.ReorderAndFilterNestedListResponse(ctx, planMsc.ListValue, listVal, "service")
+		if !reorderDiags.HasError() {
+			listVal = reOrderedList.(basetypes.ListValue)
+		}
+	}
+	m.MemberServiceCommunication = internaltypes.UnorderedListValue{ListValue: listVal}
 	m.MgmtPortSetting = FlattenMemberMgmtPortSetting(ctx, from.MgmtPortSetting, diags)
 	m.MmdbEaBuildTime = flex.FlattenInt64Pointer(from.MmdbEaBuildTime)
 	m.MmdbGeoipBuildTime = flex.FlattenInt64Pointer(from.MmdbGeoipBuildTime)

--- a/internal/service/grid/model_member_member_service_communication.go
+++ b/internal/service/grid/model_member_member_service_communication.go
@@ -3,9 +3,11 @@ package grid
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
@@ -28,13 +30,31 @@ var MemberMemberServiceCommunicationAttrTypes = map[string]attr.Type{
 
 var MemberMemberServiceCommunicationResourceSchemaAttributes = map[string]schema.Attribute{
 	"service": schema.StringAttribute{
-		Optional:            true,
-		Computed:            true,
+		Optional: true,
+		Computed: true,
+		Validators: []validator.String{
+			stringvalidator.OneOf(
+				"AD",
+				"GRID",
+				"GRID_BACKUP",
+				"MAIL",
+				"NTP",
+				"OCSP",
+				"REPORTING",
+				"REPORTING_BACKUP",
+			),
+		},
 		MarkdownDescription: "The service for a Grid member.",
 	},
 	"type": schema.StringAttribute{
-		Optional:            true,
-		Computed:            true,
+		Optional: true,
+		Computed: true,
+		Validators: []validator.String{
+			stringvalidator.OneOf(
+				"IPV4",
+				"IPV6",
+			),
+		},
 		MarkdownDescription: "Communication type.",
 	},
 	"option": schema.StringAttribute{

--- a/internal/service/grid/model_member_member_service_communication.go
+++ b/internal/service/grid/model_member_member_service_communication.go
@@ -28,10 +28,12 @@ var MemberMemberServiceCommunicationAttrTypes = map[string]attr.Type{
 
 var MemberMemberServiceCommunicationResourceSchemaAttributes = map[string]schema.Attribute{
 	"service": schema.StringAttribute{
+		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "The service for a Grid member.",
 	},
 	"type": schema.StringAttribute{
+		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "Communication type.",
 	},

--- a/internal/service/grid/model_member_member_service_communication.go
+++ b/internal/service/grid/model_member_member_service_communication.go
@@ -62,7 +62,6 @@ func (m *MemberMemberServiceCommunicationModel) Expand(ctx context.Context, diag
 	to := &grid.MemberMemberServiceCommunication{
 		Service: flex.ExpandStringPointer(m.Service),
 		Type:    flex.ExpandStringPointer(m.Type),
-		Option:  flex.ExpandStringPointer(m.Option),
 	}
 	return to
 }

--- a/internal/service/grid/model_member_member_service_communication.go
+++ b/internal/service/grid/model_member_member_service_communication.go
@@ -59,7 +59,11 @@ func (m *MemberMemberServiceCommunicationModel) Expand(ctx context.Context, diag
 	if m == nil {
 		return nil
 	}
-	to := &grid.MemberMemberServiceCommunication{}
+	to := &grid.MemberMemberServiceCommunication{
+		Service: flex.ExpandStringPointer(m.Service),
+		Type:    flex.ExpandStringPointer(m.Type),
+		Option:  flex.ExpandStringPointer(m.Option),
+	}
 	return to
 }
 


### PR DESCRIPTION
Issue: The member_service_communication field was incorrectly marked as computed.

Fix: Updated the field to be optional and implemented the necessary changes. 
During validation, an issue related to unordered list changes was identified, so additional modifications were made to handle unordered lists correctly and prevent provider crashes.