### PR TITLE
[FIX][NPA-1832]- Modifed expand function to pass dns traffic capture during update operation

### DIFF
--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -146,7 +146,7 @@ func (r *MemberResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	res := apiRes.CreateMemberResponseAsObject.GetResult()
 
-	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() {
+	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() ||(!data.TrafficCaptureAuthDnsSetting.IsUnknown() && !data.TrafficCaptureAuthDnsSetting.IsNull()) {
 		apiRes2, _, err2 := r.client.GridAPI.
 			MemberAPI.
 			Update(ctx, utils.ExtractResourceRef(*res.Ref)).

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -146,7 +146,7 @@ func (r *MemberResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	res := apiRes.CreateMemberResponseAsObject.GetResult()
 
-	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() ||(!data.TrafficCaptureAuthDnsSetting.IsUnknown() && !data.TrafficCaptureAuthDnsSetting.IsNull()) {
+	if !data.PreProvisioning.IsUnknown() && !data.PreProvisioning.IsNull() || (!data.TrafficCaptureAuthDnsSetting.IsUnknown() && !data.TrafficCaptureAuthDnsSetting.IsNull()) {
 		apiRes2, _, err2 := r.client.GridAPI.
 			MemberAPI.
 			Update(ctx, utils.ExtractResourceRef(*res.Ref)).

--- a/internal/service/grid/member_resource_test.go
+++ b/internal/service/grid/member_resource_test.go
@@ -2892,7 +2892,7 @@ func TestAccMemberResource_TrafficCaptureAuthDnsSetting(t *testing.T) {
 	var v grid.Member
 
 	hostName := fmt.Sprintf("infoblox-%s.localdomain", acctest.RandomName())
-	vipAddress := "172.28.38.141"
+	vipAddress := "172.28.38.148"
 
 	trafficCaptureAuthDnsSettingVal := map[string]any{
 		"auth_dns_latency_listen_on_source": "VIP_V4",

--- a/internal/service/grid/member_resource_test.go
+++ b/internal/service/grid/member_resource_test.go
@@ -2892,11 +2892,13 @@ func TestAccMemberResource_TrafficCaptureAuthDnsSetting(t *testing.T) {
 	var v grid.Member
 
 	hostName := fmt.Sprintf("infoblox-%s.localdomain", acctest.RandomName())
-	vipAddress := "172.28.38.148"
+	vipAddress := "172.28.38.141"
 
 	trafficCaptureAuthDnsSettingVal := map[string]any{
 		"auth_dns_latency_listen_on_source": "VIP_V4",
-		"auth_dns_latency_trigger_enable":   false,
+		"auth_dns_latency_trigger_enable":   true,
+		"auth_dns_latency_threshold":        45,
+		"auth_dns_latency_reset":            35,
 	}
 	trafficCaptureAuthDnsSettingValUpdated := map[string]any{
 		"auth_dns_latency_listen_on_source": "VIP_V4",
@@ -2918,8 +2920,10 @@ func TestAccMemberResource_TrafficCaptureAuthDnsSetting(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMemberExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "traffic_capture_auth_dns_setting.auth_dns_latency_listen_on_source", "VIP_V4"),
-					resource.TestCheckResourceAttr(resourceName, "traffic_capture_auth_dns_setting.auth_dns_latency_trigger_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_capture_auth_dns_setting.auth_dns_latency_trigger_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "use_traffic_capture_auth_dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_capture_auth_dns_setting.auth_dns_latency_threshold", "45"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_capture_auth_dns_setting.auth_dns_latency_reset", "35"),
 				),
 			},
 			{

--- a/internal/service/grid/model_member.go
+++ b/internal/service/grid/model_member.go
@@ -918,7 +918,6 @@ func (m *MemberModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 		SyslogSize:                      flex.ExpandInt64Pointer(m.SyslogSize),
 		ThresholdTraps:                  flex.ExpandFrameworkListNestedBlock(ctx, m.ThresholdTraps, diags, ExpandMemberThresholdTraps),
 		TimeZone:                        flex.ExpandStringPointer(m.TimeZone),
-		TrafficCaptureAuthDnsSetting:    ExpandMemberTrafficCaptureAuthDnsSetting(ctx, m.TrafficCaptureAuthDnsSetting, diags),
 		TrafficCaptureChrSetting:        ExpandMemberTrafficCaptureChrSetting(ctx, m.TrafficCaptureChrSetting, diags),
 		TrafficCaptureQpsSetting:        ExpandMemberTrafficCaptureQpsSetting(ctx, m.TrafficCaptureQpsSetting, diags),
 		TrafficCaptureRecDnsSetting:     ExpandMemberTrafficCaptureRecDnsSetting(ctx, m.TrafficCaptureRecDnsSetting, diags),
@@ -951,6 +950,7 @@ func (m *MemberModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 
 	if !isCreate {
 		to.PreProvisioning = ExpandMemberPreProvisioning(ctx, m.PreProvisioning, diags)
+		to.TrafficCaptureAuthDnsSetting =   ExpandMemberTrafficCaptureAuthDnsSetting(ctx, m.TrafficCaptureAuthDnsSetting, diags)
 	}
 
 	if m.ConfigureCspMemberSetting.ValueBool() {

--- a/internal/service/grid/model_member.go
+++ b/internal/service/grid/model_member.go
@@ -950,7 +950,7 @@ func (m *MemberModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCre
 
 	if !isCreate {
 		to.PreProvisioning = ExpandMemberPreProvisioning(ctx, m.PreProvisioning, diags)
-		to.TrafficCaptureAuthDnsSetting =   ExpandMemberTrafficCaptureAuthDnsSetting(ctx, m.TrafficCaptureAuthDnsSetting, diags)
+		to.TrafficCaptureAuthDnsSetting = ExpandMemberTrafficCaptureAuthDnsSetting(ctx, m.TrafficCaptureAuthDnsSetting, diags)
 	}
 
 	if m.ConfigureCspMemberSetting.ValueBool() {


### PR DESCRIPTION
Issue: 
DNS traffic capture settings cannot be passed in the payload during a POST operation, as WAPI throws an error.

Fix: 
To address this, the create function in the member object was modified to allow DNS traffic capture settings during the update operation by calling the client logic already present in Terraform's create function.