### PR TITLE
Update Validate Config to check when ms_enable_switchover_interval value is not defined

### DIFF
--- a/internal/service/dhcp/dhcpfailover_resource.go
+++ b/internal/service/dhcp/dhcpfailover_resource.go
@@ -459,7 +459,6 @@ func (r *DhcpfailoverResource) ValidateConfig(ctx context.Context, req resource.
 		}
 	}
 
-	// Only validate when both values are explicitly known
 	if !data.UseMsSwitchoverInterval.IsNull() && !data.UseMsSwitchoverInterval.IsUnknown() && data.UseMsSwitchoverInterval.ValueBool() {
 		if data.MsEnableSwitchoverInterval.IsNull() || data.MsEnableSwitchoverInterval.IsUnknown() || !data.MsEnableSwitchoverInterval.ValueBool() {
 			resp.Diagnostics.AddError(

--- a/internal/service/dhcp/dhcpfailover_resource.go
+++ b/internal/service/dhcp/dhcpfailover_resource.go
@@ -461,8 +461,7 @@ func (r *DhcpfailoverResource) ValidateConfig(ctx context.Context, req resource.
 
 	// Only validate when both values are explicitly known
 	if !data.UseMsSwitchoverInterval.IsNull() && !data.UseMsSwitchoverInterval.IsUnknown() &&
-		data.UseMsSwitchoverInterval.ValueBool() &&
-		!data.MsEnableSwitchoverInterval.IsNull() && !data.MsEnableSwitchoverInterval.IsUnknown() &&
+		data.UseMsSwitchoverInterval.ValueBool() && !data.MsEnableSwitchoverInterval.IsUnknown() &&
 		!data.MsEnableSwitchoverInterval.ValueBool() {
 		resp.Diagnostics.AddError(
 			"Invalid Configuration",

--- a/internal/service/dhcp/dhcpfailover_resource.go
+++ b/internal/service/dhcp/dhcpfailover_resource.go
@@ -460,12 +460,12 @@ func (r *DhcpfailoverResource) ValidateConfig(ctx context.Context, req resource.
 	}
 
 	// Only validate when both values are explicitly known
-	if !data.UseMsSwitchoverInterval.IsNull() && !data.UseMsSwitchoverInterval.IsUnknown() &&
-		data.UseMsSwitchoverInterval.ValueBool() && !data.MsEnableSwitchoverInterval.IsUnknown() &&
-		!data.MsEnableSwitchoverInterval.ValueBool() {
-		resp.Diagnostics.AddError(
-			"Invalid Configuration",
-			"ms_enable_switchover_interval cannot be false when use_ms_switchover_interval is true.",
-		)
+	if !data.UseMsSwitchoverInterval.IsNull() && !data.UseMsSwitchoverInterval.IsUnknown() && data.UseMsSwitchoverInterval.ValueBool() {
+		if data.MsEnableSwitchoverInterval.IsNull() || data.MsEnableSwitchoverInterval.IsUnknown() || !data.MsEnableSwitchoverInterval.ValueBool() {
+			resp.Diagnostics.AddError(
+				"Invalid Configuration",
+				"ms_enable_switchover_interval must be set when use_ms_switchover_interval is true.",
+			)
+		}
 	}
 }


### PR DESCRIPTION
This pull request updates the validation logic for the `DhcpfailoverResource` configuration to improve clarity and correctness when handling the `use_ms_switchover_interval` and `ms_enable_switchover_interval` fields.

Validation logic improvements:

* Updated the conditional logic to ensure that when `use_ms_switchover_interval` is explicitly set to true, `ms_enable_switchover_interval` must also be explicitly set to true; otherwise, an error is raised. The error message was also clarified to indicate that `ms_enable_switchover_interval` must be set when `use_ms_switchover_interval` is true.
