### PR TITLE
[FIX][NPA-1847] - Added a validation on node_info field 

### DIFF
--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -556,38 +556,33 @@ func (r *MemberResource) ValidateConfig(ctx context.Context, req resource.Valida
 				mgmtCheckComplete = true
 			}
 		}
-		 // enableHaFalse: true when enable_ha is null (defaults to false) or explicitly false.
-        // Skipped when enable_ha is unknown (value not yet determined at plan time).
-        enableHaFalse := data.EnableHa.IsNull() || (!data.EnableHa.IsUnknown() && !data.EnableHa.ValueBool())
-        // enableHaTrue: true only when enable_ha is explicitly set to true.
-        enableHaTrue := !data.EnableHa.IsNull() && !data.EnableHa.IsUnknown() && data.EnableHa.ValueBool()
+		// enableHaFalse: true when enable_ha is null (defaults to false) or explicitly false.
+		// Skipped when enable_ha is unknown (value not yet determined at plan time).
+		enableHaFalse := data.EnableHa.IsNull() || (!data.EnableHa.IsUnknown() && !data.EnableHa.ValueBool())
+		// enableHaTrue: true only when enable_ha is explicitly set to true.
+		enableHaTrue := !data.EnableHa.IsNull() && !data.EnableHa.IsUnknown() && data.EnableHa.ValueBool()
 
-        nodeCount := len(nodeInfo)
+		nodeCount := len(nodeInfo)
 
-        // Condition 1: len(nodeInfo) == 2 requires enable_ha to be true
-        if nodeCount == 2 && enableHaFalse {
-            resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info has 2 nodes")
-        }
+		// Condition 1: len(nodeInfo) == 2 requires enable_ha to be true
+		if nodeCount == 2 && enableHaFalse {
+			resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info has 2 nodes")
+		}
 
-        // Condition 2: enable_ha true requires exactly 2 nodes (not more)
-        if enableHaTrue && nodeCount > 2 {
-            resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true")
-        }
+		// Condition 2: enable_ha true requires exactly 2 nodes (not more)
+		if enableHaTrue && nodeCount > 2 {
+			resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true")
+		}
 
-        // Condition 3a: len(nodeInfo) > 2 with enable_ha false (or not set) is not allowed
-        if nodeCount > 2 && enableHaFalse {
-            resp.Diagnostics.AddError("Validation Error", "node_info cannot have more than 2 nodes when enable_ha is false")
-        }
+		// Condition 3a: len(nodeInfo) > 2 with enable_ha false (or not set) is not allowed
+		if nodeCount > 2 && enableHaFalse {
+			resp.Diagnostics.AddError("Validation Error", "node_info cannot have more than 2 nodes when enable_ha is false")
+		}
 
-        // Condition 3b: len(nodeInfo) == 1 with enable_ha false (or not set) is not allowed
-        if nodeCount == 1 && enableHaFalse {
-            resp.Diagnostics.AddError("Validation Error", "node_info with a single node is not valid when enable_ha is false; provide exactly 2 nodes with enable_ha set to true, or omit node_info")
-        }
-
-        // Condition 3c: len(nodeInfo) == 1 with enable_ha true is not allowed
-        if nodeCount == 1 && enableHaTrue {
-            resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true; a single node_info entry is not valid")
-        }
+		// Condition 3b: len(nodeInfo) == 1 with enable_ha true is not allowed
+		if nodeCount == 1 && enableHaTrue {
+			resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true; a single node_info entry is not valid")
+		}
 	}
 
 	if !data.MgmtPortSetting.IsNull() && !data.MgmtPortSetting.IsUnknown() {

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -558,10 +558,16 @@ func (r *MemberResource) ValidateConfig(ctx context.Context, req resource.Valida
 		}
 
 		if len(nodeInfo) == 2 {
-			if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
-				resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info contains 2 nodes")
-			}
-		}
+            if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
+                resp.Diagnostics.AddError("Validation Error", "node_info contains 2 nodes but enable_ha is not set to true. Either set enable_ha = true to enable HA mode, or configure only a single node in node_info when enable_ha is false")
+            }
+        } else if len(nodeInfo) > 2 {
+            if !data.EnableHa.IsNull() && !data.EnableHa.IsUnknown() && data.EnableHa.ValueBool() {
+                resp.Diagnostics.AddError("Validation Error", "node_info must contain exactly 2 nodes when enable_ha is true")
+            } else {
+                resp.Diagnostics.AddError("Validation Error", "node_info must contain 1 node when enable_ha is false")
+            }
+        }
 	}
 
 	if !data.MgmtPortSetting.IsNull() && !data.MgmtPortSetting.IsUnknown() {

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -556,6 +556,12 @@ func (r *MemberResource) ValidateConfig(ctx context.Context, req resource.Valida
 				mgmtCheckComplete = true
 			}
 		}
+		
+		if len(nodeInfo) == 2 {
+            if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
+                resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info contains 2 nodes")
+            }
+        }
 	}
 
 	if !data.MgmtPortSetting.IsNull() && !data.MgmtPortSetting.IsUnknown() {

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -556,12 +556,12 @@ func (r *MemberResource) ValidateConfig(ctx context.Context, req resource.Valida
 				mgmtCheckComplete = true
 			}
 		}
-		
+
 		if len(nodeInfo) == 2 {
-            if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
-                resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info contains 2 nodes")
-            }
-        }
+			if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
+				resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info contains 2 nodes")
+			}
+		}
 	}
 
 	if !data.MgmtPortSetting.IsNull() && !data.MgmtPortSetting.IsUnknown() {

--- a/internal/service/grid/member_resource.go
+++ b/internal/service/grid/member_resource.go
@@ -556,17 +556,37 @@ func (r *MemberResource) ValidateConfig(ctx context.Context, req resource.Valida
 				mgmtCheckComplete = true
 			}
 		}
+		 // enableHaFalse: true when enable_ha is null (defaults to false) or explicitly false.
+        // Skipped when enable_ha is unknown (value not yet determined at plan time).
+        enableHaFalse := data.EnableHa.IsNull() || (!data.EnableHa.IsUnknown() && !data.EnableHa.ValueBool())
+        // enableHaTrue: true only when enable_ha is explicitly set to true.
+        enableHaTrue := !data.EnableHa.IsNull() && !data.EnableHa.IsUnknown() && data.EnableHa.ValueBool()
 
-		if len(nodeInfo) == 2 {
-            if data.EnableHa.IsNull() || data.EnableHa.IsUnknown() || !data.EnableHa.ValueBool() {
-                resp.Diagnostics.AddError("Validation Error", "node_info contains 2 nodes but enable_ha is not set to true. Either set enable_ha = true to enable HA mode, or configure only a single node in node_info when enable_ha is false")
-            }
-        } else if len(nodeInfo) > 2 {
-            if !data.EnableHa.IsNull() && !data.EnableHa.IsUnknown() && data.EnableHa.ValueBool() {
-                resp.Diagnostics.AddError("Validation Error", "node_info must contain exactly 2 nodes when enable_ha is true")
-            } else {
-                resp.Diagnostics.AddError("Validation Error", "node_info must contain 1 node when enable_ha is false")
-            }
+        nodeCount := len(nodeInfo)
+
+        // Condition 1: len(nodeInfo) == 2 requires enable_ha to be true
+        if nodeCount == 2 && enableHaFalse {
+            resp.Diagnostics.AddError("Validation Error", "enable_ha must be true when node_info has 2 nodes")
+        }
+
+        // Condition 2: enable_ha true requires exactly 2 nodes (not more)
+        if enableHaTrue && nodeCount > 2 {
+            resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true")
+        }
+
+        // Condition 3a: len(nodeInfo) > 2 with enable_ha false (or not set) is not allowed
+        if nodeCount > 2 && enableHaFalse {
+            resp.Diagnostics.AddError("Validation Error", "node_info cannot have more than 2 nodes when enable_ha is false")
+        }
+
+        // Condition 3b: len(nodeInfo) == 1 with enable_ha false (or not set) is not allowed
+        if nodeCount == 1 && enableHaFalse {
+            resp.Diagnostics.AddError("Validation Error", "node_info with a single node is not valid when enable_ha is false; provide exactly 2 nodes with enable_ha set to true, or omit node_info")
+        }
+
+        // Condition 3c: len(nodeInfo) == 1 with enable_ha true is not allowed
+        if nodeCount == 1 && enableHaTrue {
+            resp.Diagnostics.AddError("Validation Error", "node_info must have exactly 2 nodes when enable_ha is true; a single node_info entry is not valid")
         }
 	}
 

--- a/internal/service/grid/member_resource_test.go
+++ b/internal/service/grid/member_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -1937,6 +1938,11 @@ func TestAccMemberResource_NodeInfo(t *testing.T) {
 				),
 			},
 			// Update and Read
+			{
+				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
+					vipAddress, "172.28.38.1", "255.255.254.0", "false", 113, nodeInfoValUpdated, mgmtPortSettingVal),
+				ExpectError: regexp.MustCompile("enable_ha must be true when node_info contains 2 nodes"),
+			},
 			{
 				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
 					vipAddress, "172.28.38.1", "255.255.254.0", "true", 113, nodeInfoValUpdated, mgmtPortSettingVal),

--- a/internal/service/grid/member_resource_test.go
+++ b/internal/service/grid/member_resource_test.go
@@ -1855,6 +1855,68 @@ func TestAccMemberResource_NodeInfo(t *testing.T) {
 		},
 	}
 
+	nodeInfoSingleNode := []map[string]any{
+		{
+			"lan_ha_port_setting": map[string]any{
+				"ha_cloud_attribute": "UNK",
+				"ha_ip_address":      "172.28.38.12",
+				"ha_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+					"speed":                     "10",
+				},
+				"lan_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+				},
+				"mgmt_lan": "172.28.38.33",
+			},
+		},
+	}
+
+	nodeInfoThreeNodes := []map[string]any{
+		{
+			"lan_ha_port_setting": map[string]any{
+				"ha_cloud_attribute": "UNK",
+				"ha_ip_address":      "172.28.38.12",
+				"ha_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+					"speed":                     "10",
+				},
+				"lan_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+				},
+				"mgmt_lan": "172.28.38.33",
+			},
+		},
+		{
+			"lan_ha_port_setting": map[string]any{
+				"ha_cloud_attribute": "UNK",
+				"ha_ip_address":      "172.28.38.42",
+				"ha_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+					"speed":                     "10",
+				},
+				"lan_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+				},
+				"mgmt_lan": "172.28.38.44",
+			},
+		},
+		{
+			"lan_ha_port_setting": map[string]any{
+				"ha_cloud_attribute": "UNK",
+				"ha_ip_address":      "172.28.38.52",
+				"ha_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+					"speed":                     "10",
+				},
+				"lan_port_setting": map[string]any{
+					"auto_port_setting_enabled": true,
+				},
+				"mgmt_lan": "172.28.38.55",
+			},
+		},
+	}
+
 	nodeInfoMGMTIPv4 := []map[string]any{
 		{
 			"mgmt_network_setting": map[string]any{
@@ -1941,7 +2003,31 @@ func TestAccMemberResource_NodeInfo(t *testing.T) {
 			{
 				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
 					vipAddress, "172.28.38.1", "255.255.254.0", "false", 113, nodeInfoValUpdated, mgmtPortSettingVal),
-				ExpectError: regexp.MustCompile("enable_ha must be true when node_info contains 2 nodes"),
+				ExpectError: regexp.MustCompile("enable_ha must be true when node_info has 2 nodes"),
+			},
+			// Condition 2: enable_ha true requires exactly 2 nodes (not more)
+			{
+				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
+					vipAddress, "172.28.38.1", "255.255.254.0", "true", 113, nodeInfoThreeNodes, mgmtPortSettingVal),
+				ExpectError: regexp.MustCompile("node_info must have exactly 2 nodes when enable_ha is true"),
+			},
+			// Condition 3a: node_info > 2 with enable_ha false is not allowed
+			{
+				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
+					vipAddress, "172.28.38.1", "255.255.254.0", "false", 0, nodeInfoThreeNodes, mgmtPortSettingVal),
+				ExpectError: regexp.MustCompile("node_info cannot have more than 2 nodes when enable_ha is false"),
+			},
+			// Condition 3b: single node with enable_ha false is not allowed
+			// {
+			// 	Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
+			// 		vipAddress, "172.28.38.1", "255.255.254.0", "false", 0, nodeInfoSingleNode, mgmtPortSettingVal),
+			// 	ExpectError: regexp.MustCompile("node_info with a single node is not valid when enable_ha is false"),
+			// },
+			//Condition 3c: single node with enable_ha true is not allowed
+			{
+				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
+					vipAddress, "172.28.38.1", "255.255.254.0", "true", 113, nodeInfoSingleNode, mgmtPortSettingVal),
+				ExpectError: regexp.MustCompile(`node_info must have exactly 2 nodes when enable_ha is true; a single\s+node_info entry is not valid`),
 			},
 			{
 				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",

--- a/internal/service/grid/member_resource_test.go
+++ b/internal/service/grid/member_resource_test.go
@@ -2017,13 +2017,7 @@ func TestAccMemberResource_NodeInfo(t *testing.T) {
 					vipAddress, "172.28.38.1", "255.255.254.0", "false", 0, nodeInfoThreeNodes, mgmtPortSettingVal),
 				ExpectError: regexp.MustCompile("node_info cannot have more than 2 nodes when enable_ha is false"),
 			},
-			// Condition 3b: single node with enable_ha false is not allowed
-			// {
-			// 	Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
-			// 		vipAddress, "172.28.38.1", "255.255.254.0", "false", 0, nodeInfoSingleNode, mgmtPortSettingVal),
-			// 	ExpectError: regexp.MustCompile("node_info with a single node is not valid when enable_ha is false"),
-			// },
-			//Condition 3c: single node with enable_ha true is not allowed
+			//Condition 3b: single node with enable_ha true is not allowed
 			{
 				Config: testAccMemberNodeInfo(hostName, "IPV4", "VNIOS", "ALL_V4",
 					vipAddress, "172.28.38.1", "255.255.254.0", "true", 113, nodeInfoSingleNode, mgmtPortSettingVal),


### PR DESCRIPTION
**Issue:** When `node_info` contained two nodes and `enable_ha` was set to `false`, the WAPI response returned only a single node because the member was treated as a standalone node and `mgmt_lan` information was also not returned.

**Fix:** Added validation to ensure that `enable_ha` is set to `true` whenever `node_info` contains two nodes, preventing invalid configurations and ensuring the expected node and `mgmt_lan` data are returned.
