### PR TITLE
Integration test case fix for ipv6 and ipv4 network container 

### DIFF
--- a/internal/service/ipam/model_ipv6networkcontainer.go
+++ b/internal/service/ipam/model_ipv6networkcontainer.go
@@ -809,6 +809,11 @@ func (m *Ipv6networkcontainerModel) Flatten(ctx context.Context, from *ipam.Ipv6
 	m.Utilization = flex.FlattenInt64Pointer(from.Utilization)
 	m.ValidLifetime = flex.FlattenInt64Pointer(from.ValidLifetime)
 	m.ZoneAssociations = flex.FlattenFrameworkListNestedBlock(ctx, from.ZoneAssociations, Ipv6networkcontainerZoneAssociationsAttrTypes, diags, FlattenIpv6networkcontainerZoneAssociations)
+	// When null/unknown (e.g. data source or import), apply the schema default (true)
+	if m.RemoveSubnets.IsNull() || m.RemoveSubnets.IsUnknown() {
+		defaultVal := true
+		m.RemoveSubnets = types.BoolPointerValue(&defaultVal)
+	}
 }
 
 func ExpandIpv6NetworkcontainerNetwork(str cidrtypes.IPv6Prefix) *ipam.Ipv6networkcontainerNetwork {

--- a/internal/service/ipam/model_networkcontainer.go
+++ b/internal/service/ipam/model_networkcontainer.go
@@ -719,6 +719,8 @@ var NetworkcontainerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"remove_subnets": schema.BoolAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             booldefault.StaticBool(true),
 		MarkdownDescription: "Remove subnets delete option. Determines whether all child objects should be removed alongside with the network container or child objects should be assigned to another parental container. By default child objects are deleted with the network container.",
 	},
 	"restart_if_needed": schema.BoolAttribute{
@@ -1202,6 +1204,10 @@ func (m *NetworkcontainerModel) Flatten(ctx context.Context, from *ipam.Networkc
 	m.UseZoneAssociations = types.BoolPointerValue(from.UseZoneAssociations)
 	m.Utilization = flex.FlattenInt64Pointer(from.Utilization)
 	m.ZoneAssociations = flex.FlattenFrameworkListNestedBlock(ctx, from.ZoneAssociations, NetworkcontainerZoneAssociationsAttrTypes, diags, FlattenNetworkcontainerZoneAssociations)
+	if m.RemoveSubnets.IsNull() || m.RemoveSubnets.IsUnknown() {
+		defaultVal := true
+		m.RemoveSubnets = types.BoolPointerValue(&defaultVal)
+	}
 }
 
 func ExpandNetworkcontainerNetwork(str cidrtypes.IPv4Prefix) *ipam.NetworkcontainerNetwork {


### PR DESCRIPTION
Set the default value to the state file when the value is NULL or UNKNOWN 

When null/unknown (e.g. data source or import), apply the schema default (true)