### PR TITLE
Fix `CopyFieldFromPlanToRespObject` func to discard unknown plan values

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -764,6 +764,10 @@ func CopyFieldFromPlanToRespObject(ctx context.Context, planValue, respValue att
 		return respValue, &diags
 	}
 
+	if planFieldValue.IsUnknown() {
+		return respValue, &diags
+	}
+
 	if _, exists := respAttrs[fieldName]; !exists {
 		diags.AddError(
 			"Field Not Found in Response",


### PR DESCRIPTION
Fixed utils method to copy plan vals, ignored copying if plan val is unknown