### PR TITLE
Revert "[DHCP] Add acceptance tests and fix state drift for template, enable_immediate_discovery, and restart_if_needed fields"

### DIFF
--- a/docs/data-sources/dhcp_ipv6range.md
+++ b/docs/data-sources/dhcp_ipv6range.md
@@ -83,7 +83,6 @@ Optional:
 - `server_association_type` (String) The type of server that is going to serve the range. Valid values are: * MEMBER * NONE
 - `start_addr` (String) The IPv6 Address starting address of the DHCP IPv6 range.
 - `subscribe_settings` (Attributes) The DHCP IPv6 Range Cisco ISE subscribe settings. (see [below for nested schema](#nestedatt--result--subscribe_settings))
-- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `use_blackout_setting` (Boolean) Use flag for: discovery_blackout_setting , port_control_blackout_setting, same_port_control_discovery_blackout
 - `use_discovery_basic_polling_settings` (Boolean) Use flag for: discovery_basic_poll_settings
 - `use_enable_discovery` (Boolean) Use flag for: discovery_member , enable_discovery
@@ -96,6 +95,7 @@ Read-Only:
 - `discover_now_status` (String) Discover now status for this range.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object , including default and internal attributes.
 - `ref` (String) The reference to the object.
+- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 
 <a id="nestedatt--result--cloud_info"></a>
 ### Nested Schema for `result.cloud_info`

--- a/docs/data-sources/dhcp_range.md
+++ b/docs/data-sources/dhcp_range.md
@@ -112,7 +112,6 @@ Optional:
 - `split_member` (Attributes) This field contains the split member that will run the DHCP service for this range. If this is not set, the range will be served by the member that is currently serving the network. (see [below for nested schema](#nestedatt--result--split_member))
 - `split_scope_exclusion_percent` (Number) This field controls the percentage used when creating a split scope. Valid values are numbers between 1 and 99. If the value is 40, it means that the top 40% of the exclusion will be created on the DHCP range assigned to {next_available_ip:next_available_ip} and the lower 60% of the range will be assigned to DHCP range assigned to {next_available_ip:next_available_ip}
 - `subscribe_settings` (Attributes) The subscribe settings for the range. This field is used to configure the subscription settings for the DHCP range. It includes information about the subscription, such as the subscriber's email address and whether the subscription is enabled. (see [below for nested schema](#nestedatt--result--subscribe_settings))
-- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `unknown_clients` (String) Permission for unknown clients. This can be 'Allow' or 'Deny'. If set to 'Deny', unknown clients will be denied IP addresses. Known clients include roaming hosts and clients with fixed addresses or DHCP host entries. Unknown clients include clients that are not roaming hosts and clients that do not have fixed addresses or DHCP host entries.
 - `update_dns_on_lease_renewal` (Boolean) This field controls whether the DHCP server updates DNS when a DHCP lease is renewed.
 - `use_blackout_setting` (Boolean) Use flag for: discovery_blackout_setting , port_control_blackout_setting, same_port_control_discovery_blackout
@@ -153,6 +152,7 @@ Read-Only:
 - `ms_ad_user_data` (Attributes) This field contains the Microsoft AD user data for this range. This data is used to create a user in the Microsoft AD when a lease is assigned to a host in this range. (see [below for nested schema](#nestedatt--result--ms_ad_user_data))
 - `ref` (String) The reference to the object.
 - `static_hosts` (Number) The number of static DHCP addresses configured in the range.
+- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `total_hosts` (Number) The total number of DHCP addresses configured in the range.
 
 <a id="nestedatt--result--cloud_info"></a>

--- a/docs/resources/dhcp_ipv6range.md
+++ b/docs/resources/dhcp_ipv6range.md
@@ -102,7 +102,6 @@ resource "nios_dhcp_ipv6range" "create_ipv6range_with_additional_fields" {
 - `server_association_type` (String) The type of server that is going to serve the range. Valid values are: * MEMBER * NONE
 - `start_addr` (String) The IPv6 Address starting address of the DHCP IPv6 range.
 - `subscribe_settings` (Attributes) The DHCP IPv6 Range Cisco ISE subscribe settings. (see [below for nested schema](#nestedatt--subscribe_settings))
-- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `use_blackout_setting` (Boolean) Use flag for: discovery_blackout_setting , port_control_blackout_setting, same_port_control_discovery_blackout
 - `use_discovery_basic_polling_settings` (Boolean) Use flag for: discovery_basic_poll_settings
 - `use_enable_discovery` (Boolean) Use flag for: discovery_member , enable_discovery
@@ -115,6 +114,7 @@ resource "nios_dhcp_ipv6range" "create_ipv6range_with_additional_fields" {
 - `discover_now_status` (String) Discover now status for this range.
 - `extattrs_all` (Map of String) Extensible attributes associated with the object , including default and internal attributes.
 - `ref` (String) The reference to the object.
+- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 
 <a id="nestedatt--cloud_info"></a>
 ### Nested Schema for `cloud_info`

--- a/docs/resources/dhcp_range.md
+++ b/docs/resources/dhcp_range.md
@@ -131,7 +131,6 @@ resource "nios_dhcp_range" "create_range_with_additional_fields" {
 - `split_member` (Attributes) This field contains the split member that will run the DHCP service for this range. If this is not set, the range will be served by the member that is currently serving the network. (see [below for nested schema](#nestedatt--split_member))
 - `split_scope_exclusion_percent` (Number) This field controls the percentage used when creating a split scope. Valid values are numbers between 1 and 99. If the value is 40, it means that the top 40% of the exclusion will be created on the DHCP range assigned to {next_available_ip:next_available_ip} and the lower 60% of the range will be assigned to DHCP range assigned to {next_available_ip:next_available_ip}
 - `subscribe_settings` (Attributes) The subscribe settings for the range. This field is used to configure the subscription settings for the DHCP range. It includes information about the subscription, such as the subscriber's email address and whether the subscription is enabled. (see [below for nested schema](#nestedatt--subscribe_settings))
-- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `unknown_clients` (String) Permission for unknown clients. This can be 'Allow' or 'Deny'. If set to 'Deny', unknown clients will be denied IP addresses. Known clients include roaming hosts and clients with fixed addresses or DHCP host entries. Unknown clients include clients that are not roaming hosts and clients that do not have fixed addresses or DHCP host entries.
 - `update_dns_on_lease_renewal` (Boolean) This field controls whether the DHCP server updates DNS when a DHCP lease is renewed.
 - `use_blackout_setting` (Boolean) Use flag for: discovery_blackout_setting , port_control_blackout_setting, same_port_control_discovery_blackout
@@ -172,6 +171,7 @@ resource "nios_dhcp_range" "create_range_with_additional_fields" {
 - `ms_ad_user_data` (Attributes) This field contains the Microsoft AD user data for this range. This data is used to create a user in the Microsoft AD when a lease is assigned to a host in this range. (see [below for nested schema](#nestedatt--ms_ad_user_data))
 - `ref` (String) The reference to the object.
 - `static_hosts` (Number) The number of static DHCP addresses configured in the range.
+- `template` (String) If set on creation, the range will be created according to the values specified in the named template.
 - `total_hosts` (Number) The total number of DHCP addresses configured in the range.
 
 <a id="nestedatt--cloud_info"></a>

--- a/internal/service/dhcp/dhcpoptionspace_resource_test.go
+++ b/internal/service/dhcp/dhcpoptionspace_resource_test.go
@@ -124,42 +124,6 @@ func TestAccDhcpoptionspaceResource_Name(t *testing.T) {
 	})
 }
 
-func TestAccDhcpoptionspaceResource_OptionDefinitions(t *testing.T) {
-	resourceName := "nios_dhcp_optionspace.test_option_definitions"
-	var v dhcp.Dhcpoptionspace
-	optionSpace := acctest.RandomNameWithPrefix("dhcp-option-space")
-	optionDefName := acctest.RandomNameWithPrefix("dhcp-option-definition")
-	optionDefName2 := acctest.RandomNameWithPrefix("dhcp-option-definition")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccDhcpoptionspaceOptionDefinitions(optionSpace, optionDefName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDhcpoptionspaceExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition", "name", optionDefName),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition", "code", "210"),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition", "type", "string"),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition", "space", optionSpace),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccDhcpoptionspaceOptionDefinitionsUpdate(optionSpace, optionDefName, optionDefName2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDhcpoptionspaceExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition2", "name", optionDefName2),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition2", "code", "211"),
-					resource.TestCheckResourceAttr("nios_dhcp_optiondefinition.test_option_definition2", "space", optionSpace),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckDhcpoptionspaceExists(ctx context.Context, resourceName string, v *dhcp.Dhcpoptionspace) resource.TestCheckFunc {
 	// Verify the resource exists in the cloud
 	return func(state *terraform.State) error {
@@ -241,41 +205,4 @@ resource "nios_dhcp_optionspace" "test_name" {
     name = %q
 }
 `, name)
-}
-
-func testAccDhcpoptionspaceOptionDefinitions(optionSpace, optionDefName string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_optionspace" "test_option_definitions" {
-	name = %q
-}
-
-resource "nios_dhcp_optiondefinition" "test_option_definition" {
-	code = "210"
-	name = %q
-	type = "string"
-	space = nios_dhcp_optionspace.test_option_definitions.name
-}
-`, optionSpace, optionDefName)
-}
-
-func testAccDhcpoptionspaceOptionDefinitionsUpdate(optionSpace, optionDefName, optionDefName2 string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_optionspace" "test_option_definitions" {
-	name = %q
-}
-
-resource "nios_dhcp_optiondefinition" "test_option_definition" {
-	code = "210"
-	name = %q
-	type = "string"
-	space = nios_dhcp_optionspace.test_option_definitions.name
-}
-
-resource "nios_dhcp_optiondefinition" "test_option_definition2" {
-	code = "211"
-	name = %q
-	type = "string"
-	space = nios_dhcp_optionspace.test_option_definitions.name
-}
-`, optionSpace, optionDefName, optionDefName2)
 }

--- a/internal/service/dhcp/ipv6dhcpoptionspace_resource_test.go
+++ b/internal/service/dhcp/ipv6dhcpoptionspace_resource_test.go
@@ -156,42 +156,6 @@ func TestAccIpv6dhcpoptionspaceResource_Name(t *testing.T) {
 	})
 }
 
-func TestAccIpv6dhcpoptionspaceResource_OptionDefinitions(t *testing.T) {
-	resourceName := "nios_dhcp_ipv6optionspace.test_option_definitions"
-	var v dhcp.Ipv6dhcpoptionspace
-	optionSpace := acctest.RandomNameWithPrefix("option-space")
-	optionDefName := acctest.RandomNameWithPrefix("ipv6-option-definition")
-	optionDefName2 := acctest.RandomNameWithPrefix("ipv6-option-definition")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccIpv6dhcpoptionspaceOptionDefinitions(optionSpace, optionDefName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6dhcpoptionspaceExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition", "name", optionDefName),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition", "code", "211"),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition", "type", "string"),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition", "space", optionSpace),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccIpv6dhcpoptionspaceOptionDefinitionsUpdate(optionSpace, optionDefName, optionDefName2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6dhcpoptionspaceExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition2", "name", optionDefName2),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition2", "code", "212"),
-					resource.TestCheckResourceAttr("nios_dhcp_ipv6optiondefinition.test_option_definition2", "space", optionSpace),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckIpv6dhcpoptionspaceExists(ctx context.Context, resourceName string, v *dhcp.Ipv6dhcpoptionspace) resource.TestCheckFunc {
 	// Verify the resource exists in the cloud
 	return func(state *terraform.State) error {
@@ -285,43 +249,4 @@ resource "nios_dhcp_ipv6optionspace" "test_name" {
     name = %q
 }
 `, enterpriseNumber, name)
-}
-
-func testAccIpv6dhcpoptionspaceOptionDefinitions(optionSpace, optionDefName string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_ipv6optionspace" "test_option_definitions" {
-	enterprise_number = "5896"
-	name = %q
-}
-
-resource "nios_dhcp_ipv6optiondefinition" "test_option_definition" {
-	code = "211"
-	name = %q
-	type = "string"
-	space = nios_dhcp_ipv6optionspace.test_option_definitions.name
-}
-`, optionSpace, optionDefName)
-}
-
-func testAccIpv6dhcpoptionspaceOptionDefinitionsUpdate(optionSpace, optionDefName, optionDefName2 string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_ipv6optionspace" "test_option_definitions" {
-	enterprise_number = "5896"
-	name = %q
-}
-
-resource "nios_dhcp_ipv6optiondefinition" "test_option_definition" {
-	code = "211"
-	name = %q
-	type = "string"
-	space = nios_dhcp_ipv6optionspace.test_option_definitions.name
-}
-
-resource "nios_dhcp_ipv6optiondefinition" "test_option_definition2" {
-	code = "212"
-	name = %q
-	type = "string"
-	space = nios_dhcp_ipv6optionspace.test_option_definitions.name
-}
-`, optionSpace, optionDefName, optionDefName2)
 }

--- a/internal/service/dhcp/ipv6fixedaddress_resource_test.go
+++ b/internal/service/dhcp/ipv6fixedaddress_resource_test.go
@@ -18,11 +18,12 @@ import (
 
 var readableAttributesForIpv6fixedaddress = "address_type,allow_telnet,cli_credentials,cloud_info,comment,device_description,device_location,device_type,device_vendor,disable,disable_discovery,discover_now_status,discovered_data,domain_name,domain_name_servers,duid,extattrs,ipv6addr,ipv6prefix,ipv6prefix_bits,logic_filter_rules,mac_address,match_client,ms_ad_user_data,name,network,network_view,options,preferred_lifetime,reserved_interface,snmp3_credential,snmp_credential,use_cli_credentials,use_domain_name,use_domain_name_servers,use_logic_filter_rules,use_options,use_preferred_lifetime,use_snmp3_credential,use_snmp_credential,use_valid_lifetime,valid_lifetime"
 
-// TODO: Pending Tests
-// Reserved Interface
-
 // Objects to be present on GRID for tests
 // filteroption - ipv6_option_filter and ipv6_option_filter1
+
+// TODO: Add tests:
+// The following require additional resource/data source objects to be supported.
+// - Reserved Interface
 
 func TestAccIpv6fixedaddressResource_basic(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6fixedaddress.test"
@@ -642,43 +643,6 @@ func TestAccIpv6fixedaddressResource_Duid(t *testing.T) {
 	})
 }
 
-func TestAccIpv6fixedaddressResource_EnableImmediateDiscovery(t *testing.T) {
-	discoveryMember := utils.GetNIOSDiscoveryMemberHostName()
-	if discoveryMember == "" {
-		t.Skip("NIOS_DISCOVERY_MEMBER_HOSTNAME environment variable must be set")
-	}
-	resourceName := "nios_dhcp_ipv6fixedaddress.test_enable_immediate_discovery"
-	var v dhcp.Ipv6fixedaddress
-	ipv6Network := "2001:db8:abcd:12a4::/64"
-	ipv6addr := "2001:db8:abcd:12a4::10"
-	networkView := acctest.RandomNameWithPrefix("network-view")
-	duid := "00:01:00:01:1d:2b:3c:4d:00:0c:29:11:aa:04"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccIpv6fixedaddressEnableImmediateDiscovery(ipv6addr, duid, networkView, ipv6Network, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "enable_immediate_discovery", "true"),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccIpv6fixedaddressEnableImmediateDiscovery(ipv6addr, duid, networkView, ipv6Network, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "enable_immediate_discovery", "false"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
 func TestAccIpv6fixedaddressResource_ExtAttrs(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6fixedaddress.test_extattrs"
 	var v dhcp.Ipv6fixedaddress
@@ -1027,29 +991,6 @@ func TestAccIpv6fixedaddressResource_Network(t *testing.T) {
 	})
 }
 
-func TestAccIpv6fixedaddressResource_NetworkView(t *testing.T) {
-	resourceName := "nios_dhcp_ipv6fixedaddress.test_network_view"
-	var v dhcp.Ipv6fixedaddress
-	ipv6Network := "2001:db8:abcd:12a2::/64"
-	ipv6addr := "2001:db8:abcd:12a2::10"
-	networkView := acctest.RandomNameWithPrefix("network-view")
-	duid := "00:01:00:01:1d:2b:3c:4d:00:0c:29:11:aa:02"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccIpv6fixedaddressNetworkView(ipv6addr, duid, networkView, ipv6Network),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "network_view", networkView),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIpv6fixedaddressResource_Options(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6fixedaddress.test_options"
 	var v dhcp.Ipv6fixedaddress
@@ -1193,39 +1134,6 @@ func TestAccIpv6fixedaddressResource_ReservedInterface(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "reserved_interface", reservedInterface2),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func TestAccIpv6fixedaddressResource_RestartIfNeeded(t *testing.T) {
-	resourceName := "nios_dhcp_ipv6fixedaddress.test_restart_if_needed"
-	var v dhcp.Ipv6fixedaddress
-	ipv6Network := "2001:db8:abcd:12a3::/64"
-	ipv6addr := "2001:db8:abcd:12a3::10"
-	networkView := acctest.RandomNameWithPrefix("network-view")
-	duid := "00:01:00:01:1d:2b:3c:4d:00:0c:29:11:aa:03"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccIpv6fixedaddressRestartIfNeeded(ipv6addr, duid, networkView, ipv6Network, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "true"),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccIpv6fixedaddressRestartIfNeeded(ipv6addr, duid, networkView, ipv6Network, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6fixedaddressExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "false"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -2067,19 +1975,6 @@ resource "nios_dhcp_ipv6fixedaddress" "test_duid" {
 	return strings.Join([]string{testAccBaseNetworkWithView(networkView, ipv6Network), config}, "")
 }
 
-func testAccIpv6fixedaddressEnableImmediateDiscovery(ipv6addr, duid, networkView, ipv6Network string, enableImmediateDiscovery bool) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6fixedaddress" "test_enable_immediate_discovery" {
-	ipv6addr = %q
-	duid = %q
-	enable_immediate_discovery = %t
-	network = nios_ipam_ipv6network.test_ipv6_network.network
-	network_view = nios_ipam_network_view.parent_network_view.name
-}
-`, ipv6addr, duid, enableImmediateDiscovery)
-	return strings.Join([]string{testAccBaseNetworkWithView(networkView, ipv6Network), config}, "")
-}
-
 func testAccIpv6fixedaddressExtAttrs(ipv6addr, duid, networkView, ipv6Network string, extAttrs map[string]any) string {
 	extAttrsStr := utils.ConvertMapToHCL(extAttrs)
 	config := fmt.Sprintf(`
@@ -2247,18 +2142,6 @@ resource "nios_dhcp_ipv6fixedaddress" "test_network" {
 	return strings.Join([]string{testAccBaseWithTwoIPv6Networks(networkView, ipv6Network1, ipv6Network2), config}, "")
 }
 
-func testAccIpv6fixedaddressNetworkView(ipv6addr, duid, networkView, ipv6Network string) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6fixedaddress" "test_network_view" {
-	ipv6addr = %q
-	duid = %q
-	network = nios_ipam_ipv6network.test_ipv6_network.network
-	network_view = nios_ipam_network_view.parent_network_view.name
-}
-`, ipv6addr, duid)
-	return strings.Join([]string{testAccBaseNetworkWithView(networkView, ipv6Network), config}, "")
-}
-
 func testAccIpv6fixedaddressOptions(ipv6addr, duid, networkView, ipv6Network string, options []map[string]any) string {
 	optionsStr := convertSliceOfMapsToString(options)
 	config := fmt.Sprintf(`
@@ -2300,19 +2183,6 @@ resource "nios_dhcp_ipv6fixedaddress" "test_reserved_interface" {
     network_view = nios_ipam_network_view.parent_network_view.name
 }
 `, ipv6addr, duid, reservedInterface)
-	return strings.Join([]string{testAccBaseNetworkWithView(networkView, ipv6Network), config}, "")
-}
-
-func testAccIpv6fixedaddressRestartIfNeeded(ipv6addr, duid, networkView, ipv6Network string, restartIfNeeded bool) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6fixedaddress" "test_restart_if_needed" {
-	ipv6addr = %q
-	duid = %q
-	restart_if_needed = %t
-	network = nios_ipam_ipv6network.test_ipv6_network.network
-	network_view = nios_ipam_network_view.parent_network_view.name
-}
-`, ipv6addr, duid, restartIfNeeded)
 	return strings.Join([]string{testAccBaseNetworkWithView(networkView, ipv6Network), config}, "")
 }
 

--- a/internal/service/dhcp/ipv6range_resource.go
+++ b/internal/service/dhcp/ipv6range_resource.go
@@ -82,7 +82,7 @@ func (r *Ipv6rangeResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	payload := data.Expand(ctx, &resp.Diagnostics, true)
+	payload := data.Expand(ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -319,7 +319,7 @@ func (r *Ipv6rangeResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	payload := data.Expand(ctx, &resp.Diagnostics, false)
+	payload := data.Expand(ctx, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/dhcp/ipv6range_resource_test.go
+++ b/internal/service/dhcp/ipv6range_resource_test.go
@@ -396,8 +396,8 @@ func TestAccIpv6rangeResource_DiscoveryBlackoutSetting(t *testing.T) {
 }
 
 func TestAccIpv6rangeResource_DiscoveryMember(t *testing.T) {
-	discoveryMember := utils.GetNIOSDiscoveryMemberHostName()
-	if discoveryMember == "" || utils.GetNIOSDiscoveryMemberConfigAddrType() != "BOTH" {
+	gridMemberHostname := utils.GetNIOSDiscoveryMemberHostName()
+	if gridMemberHostname == "" || utils.GetNIOSDiscoveryMemberConfigAddrType() != "BOTH" {
 		t.Skip("Skipping test: NIOS_DISCOVERY_MEMBER_HOSTNAME must be set and Member should have IPv6 enabled")
 	}
 	var resourceName = "nios_dhcp_ipv6range.test_discovery_member"
@@ -410,10 +410,10 @@ func TestAccIpv6rangeResource_DiscoveryMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccIpv6rangeDiscoveryMember(view, "14::1", "14::10", discoveryMember, "true"),
+				Config: testAccIpv6rangeDiscoveryMember(view, "14::1", "14::10", gridMemberHostname, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "discovery_member", discoveryMember),
+					resource.TestCheckResourceAttr(resourceName, "discovery_member", gridMemberHostname),
 				),
 			},
 			// Update and Read - disable discovery
@@ -430,8 +430,8 @@ func TestAccIpv6rangeResource_DiscoveryMember(t *testing.T) {
 }
 
 func TestAccIpv6rangeResource_EnableDiscovery(t *testing.T) {
-	discoveryMember := utils.GetNIOSDiscoveryMemberHostName()
-	if discoveryMember == "" || utils.GetNIOSDiscoveryMemberConfigAddrType() != "BOTH" {
+	gridMemberHostname := utils.GetNIOSDiscoveryMemberHostName()
+	if gridMemberHostname == "" || utils.GetNIOSDiscoveryMemberConfigAddrType() != "BOTH" {
 		t.Skip("Skipping test: NIOS_DISCOVERY_MEMBER_HOSTNAME must be set and Member should have IPv6 enabled")
 	}
 	var resourceName = "nios_dhcp_ipv6range.test_enable_discovery"
@@ -444,7 +444,7 @@ func TestAccIpv6rangeResource_EnableDiscovery(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccIpv6rangeEnableDiscovery(view, "15::1", "15::10", "true", discoveryMember),
+				Config: testAccIpv6rangeEnableDiscovery(view, "15::1", "15::10", "true", gridMemberHostname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enable_discovery", "true"),
@@ -452,7 +452,7 @@ func TestAccIpv6rangeResource_EnableDiscovery(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccIpv6rangeEnableDiscovery(view, "15::1", "15::10", "false", discoveryMember),
+				Config: testAccIpv6rangeEnableDiscovery(view, "15::1", "15::10", "false", gridMemberHostname),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enable_discovery", "false"),
@@ -486,40 +486,6 @@ func TestAccIpv6rangeResource_EndAddr(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "end_addr", "14::20"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func TestAccIpv6rangeResource_EnableImmediateDiscovery(t *testing.T) {
-	discoveryMember := utils.GetNIOSDiscoveryMemberHostName()
-	if discoveryMember == "" || utils.GetNIOSDiscoveryMemberConfigAddrType() != "BOTH" {
-		t.Skip("Skipping test: NIOS_DISCOVERY_MEMBER_HOSTNAME must be set and Member should have IPv6 enabled")
-	}
-	resourceName := "nios_dhcp_ipv6range.test_enable_immediate_discovery"
-	var v dhcp.Ipv6range
-	view := acctest.RandomNameWithPrefix("network-view")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccIpv6rangeEnableImmediateDiscovery(view, "14::101", "14::110", true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "enable_immediate_discovery", "true"),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccIpv6rangeEnableImmediateDiscovery(view, "14::101", "14::110", false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "enable_immediate_discovery", "false"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -1009,36 +975,6 @@ func TestAccIpv6rangeResource_RecycleLeases(t *testing.T) {
 	})
 }
 
-func TestAccIpv6rangeResource_RestartIfNeeded(t *testing.T) {
-	resourceName := "nios_dhcp_ipv6range.test_restart_if_needed"
-	var v dhcp.Ipv6range
-	view := acctest.RandomNameWithPrefix("network-view")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccIpv6rangeRestartIfNeeded(view, "14::121", "14::130", true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "true"),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccIpv6rangeRestartIfNeeded(view, "14::121", "14::130", false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "false"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
 func TestAccIpv6rangeResource_SamePortControlDiscoveryBlackout(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6range.test_same_port_control_discovery_blackout"
 	var v dhcp.Ipv6range
@@ -1072,7 +1008,7 @@ func TestAccIpv6rangeResource_SamePortControlDiscoveryBlackout(t *testing.T) {
 func TestAccIpv6rangeResource_ServerAssociationType(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6range.test_server_association_type"
 	var v dhcp.Ipv6range
-	view := acctest.RandomNameWithPrefix("network-view")
+	view := "default"
 	memberUpdatedName := utils.GetNIOSGridMemberHostName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1133,7 +1069,6 @@ func TestAccIpv6rangeResource_StartAddr(t *testing.T) {
 func TestAccIpv6rangeResource_SubscribeSettings(t *testing.T) {
 	var resourceName = "nios_dhcp_ipv6range.test_subscribe_settings"
 	var v dhcp.Ipv6range
-	view := acctest.RandomNameWithPrefix("network-view")
 	subscribeSettings := map[string]any{
 		"enabled_attributes": []string{"DOMAINNAME", "ENDPOINT_PROFILE"},
 	}
@@ -1147,7 +1082,7 @@ func TestAccIpv6rangeResource_SubscribeSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccIpv6rangeSubscribeSettings(view, "219::1", "219::10", subscribeSettings, "true"),
+				Config: testAccIpv6rangeSubscribeSettings("test_network_view", "219::1", "219::10", subscribeSettings, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subscribe_settings.enabled_attributes.0", "DOMAINNAME"),
@@ -1156,34 +1091,13 @@ func TestAccIpv6rangeResource_SubscribeSettings(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccIpv6rangeSubscribeSettings(view, "219::1", "219::10", subscribeSettingsUpdated, "true"),
+				Config: testAccIpv6rangeSubscribeSettings("test_network_view", "219::1", "219::10", subscribeSettingsUpdated, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "subscribe_settings.enabled_attributes.0", "SECURITY_GROUP"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func TestAccIpv6rangeResource_Template(t *testing.T) {
-	resourceName := "nios_dhcp_ipv6range.test_template"
-	var v dhcp.Ipv6range
-	view := acctest.RandomNameWithPrefix("network-view")
-	templateName := acctest.RandomNameWithPrefix("ipv6range-template")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccIpv6rangeTemplate(view, "14::131", "14::140", templateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIpv6rangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "template", templateName),
-				),
-			},
 		},
 	})
 }
@@ -1964,60 +1878,14 @@ resource "nios_ipam_ipv6network" "test" {
 }
 
 resource "nios_dhcp_ipv6range" "test_use_subscribe_settings" {
-	network = nios_ipam_ipv6network.test.network
-	start_addr = %q
-	end_addr = %q
-	network_view = nios_ipam_ipv6network.test.network_view
+    network = nios_ipam_ipv6network.test.network
+    start_addr = %q
+    end_addr = %q
+    network_view = nios_ipam_ipv6network.test.network_view
 	subscribe_settings = %s
-	use_subscribe_settings = %q
+    use_subscribe_settings = %q
 }
 `, view, startAddr, endAddr, subscribeSettingsStr, useSubscribeSettings)
-}
-
-func testAccIpv6rangeEnableImmediateDiscovery(view, startAddr, endAddr string, enableImmediateDiscovery bool) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6range" "test_enable_immediate_discovery" {
-	network = nios_ipam_ipv6network.test.network
-	start_addr = %q
-	end_addr = %q
-	network_view = nios_ipam_network_view.test.name
-	enable_immediate_discovery = %t
-}
-`, startAddr, endAddr, enableImmediateDiscovery)
-	return strings.Join([]string{testAccBaseWithIpv6NetworkandView(view), config}, "")
-}
-
-func testAccIpv6rangeRestartIfNeeded(view, startAddr, endAddr string, restartIfNeeded bool) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6range" "test_restart_if_needed" {
-	network = nios_ipam_ipv6network.test.network
-	start_addr = %q
-	end_addr = %q
-	network_view = nios_ipam_network_view.test.name
-	restart_if_needed = %t
-}
-`, startAddr, endAddr, restartIfNeeded)
-	return strings.Join([]string{testAccBaseWithIpv6NetworkandView(view), config}, "")
-}
-
-func testAccIpv6rangeTemplate(view, startAddr, endAddr, templateName string) string {
-	config := fmt.Sprintf(`
-resource "nios_dhcp_ipv6_range_template" "test_template" {
-	name                = %q
-	number_of_addresses = 10
-	offset              = 1
-	cloud_api_compatible = true
-}
-
-resource "nios_dhcp_ipv6range" "test_template" {
-	network = nios_ipam_ipv6network.test.network
-	start_addr = %q
-	end_addr = %q
-	network_view = nios_ipam_network_view.test.name
-	template = nios_dhcp_ipv6_range_template.test_template.name
-}
-`, templateName, startAddr, endAddr)
-	return strings.Join([]string{testAccBaseWithIpv6NetworkandView(view), config}, "")
 }
 
 func testAccBaseWithIpv6NetworkandView(view string) string {

--- a/internal/service/dhcp/model_ipv6fixedaddress.go
+++ b/internal/service/dhcp/model_ipv6fixedaddress.go
@@ -607,11 +607,7 @@ func (m *Ipv6fixedaddressModel) Flatten(ctx context.Context, from *dhcp.Ipv6fixe
 	m.DomainName.StringValue = flex.FlattenStringPointer(from.DomainName)
 	m.DomainNameServers = flex.FlattenFrameworkListString(ctx, from.DomainNameServers, diags)
 	m.Duid = flex.FlattenDUID(from.Duid)
-	if from.EnableImmediateDiscovery != nil {
-		m.EnableImmediateDiscovery = types.BoolPointerValue(from.EnableImmediateDiscovery)
-	} else if m.EnableImmediateDiscovery.IsUnknown() {
-		m.EnableImmediateDiscovery = types.BoolNull()
-	}
+	m.EnableImmediateDiscovery = types.BoolPointerValue(from.EnableImmediateDiscovery)
 	m.ExtAttrs = FlattenExtAttrs(ctx, m.ExtAttrs, from.ExtAttrs, diags)
 	m.Ipv6addr = FlattenIpv6fixedaddressIpv6addr(from.Ipv6addr)
 	m.Ipv6prefix = flex.FlattenStringPointer(from.Ipv6prefix)

--- a/internal/service/dhcp/model_ipv6range.go
+++ b/internal/service/dhcp/model_ipv6range.go
@@ -352,12 +352,8 @@ var Ipv6rangeResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The DHCP IPv6 Range Cisco ISE subscribe settings.",
 	},
 	"template": schema.StringAttribute{
-		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "If set on creation, the range will be created according to the values specified in the named template.",
-		PlanModifiers: []planmodifier.String{
-			planmodifiers.ImmutableString(),
-		},
 	},
 	"use_blackout_setting": schema.BoolAttribute{
 		Optional:            true,
@@ -397,7 +393,7 @@ var Ipv6rangeResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 }
 
-func (m *Ipv6rangeModel) Expand(ctx context.Context, diags *diag.Diagnostics, isCreate bool) *dhcp.Ipv6range {
+func (m *Ipv6rangeModel) Expand(ctx context.Context, diags *diag.Diagnostics) *dhcp.Ipv6range {
 	if m == nil {
 		return nil
 	}
@@ -436,9 +432,6 @@ func (m *Ipv6rangeModel) Expand(ctx context.Context, diags *diag.Diagnostics, is
 		UseRecycleLeases:                 flex.ExpandBoolPointer(m.UseRecycleLeases),
 		UseSubscribeSettings:             flex.ExpandBoolPointer(m.UseSubscribeSettings),
 		NetworkView:                      flex.ExpandStringPointer(m.NetworkView),
-	}
-	if isCreate {
-		to.Template = flex.ExpandStringPointer(m.Template)
 	}
 	return to
 }
@@ -491,9 +484,7 @@ func (m *Ipv6rangeModel) Flatten(ctx context.Context, from *dhcp.Ipv6range, diag
 	m.ServerAssociationType = flex.FlattenStringPointer(from.ServerAssociationType)
 	m.StartAddr = flex.FlattenIPv6Address(from.StartAddr)
 	m.SubscribeSettings = FlattenIpv6rangeSubscribeSettings(ctx, from.SubscribeSettings, diags)
-	if m.Template.IsUnknown() || m.Template.IsNull() {
-		m.Template = flex.FlattenStringPointer(from.Template)
-	}
+	m.Template = flex.FlattenStringPointer(from.Template)
 	m.UseBlackoutSetting = types.BoolPointerValue(from.UseBlackoutSetting)
 	m.UseDiscoveryBasicPollingSettings = types.BoolPointerValue(from.UseDiscoveryBasicPollingSettings)
 	m.UseEnableDiscovery = types.BoolPointerValue(from.UseEnableDiscovery)

--- a/internal/service/dhcp/model_range.go
+++ b/internal/service/dhcp/model_range.go
@@ -783,7 +783,6 @@ var RangeResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The subscribe settings for the range. This field is used to configure the subscription settings for the DHCP range. It includes information about the subscription, such as the subscriber's email address and whether the subscription is enabled.",
 	},
 	"template": schema.StringAttribute{
-		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "If set on creation, the range will be created according to the values specified in the named template.",
 		PlanModifiers: []planmodifier.String{
@@ -1153,9 +1152,7 @@ func (m *RangeModel) Flatten(ctx context.Context, from *dhcp.Range, diags *diag.
 	m.StartAddr = flex.FlattenIPv4Address(from.StartAddr)
 	m.StaticHosts = flex.FlattenInt64Pointer(from.StaticHosts)
 	m.SubscribeSettings = FlattenRangeSubscribeSettings(ctx, from.SubscribeSettings, diags)
-	if m.Template.IsUnknown() || m.Template.IsNull() {
-		m.Template = flex.FlattenStringPointer(from.Template)
-	}
+	m.Template = flex.FlattenStringPointer(from.Template)
 	m.TotalHosts = flex.FlattenInt64Pointer(from.TotalHosts)
 	m.UnknownClients = flex.FlattenStringPointer(from.UnknownClients)
 	m.UpdateDnsOnLeaseRenewal = types.BoolPointerValue(from.UpdateDnsOnLeaseRenewal)

--- a/internal/service/dhcp/model_roaminghost.go
+++ b/internal/service/dhcp/model_roaminghost.go
@@ -708,12 +708,8 @@ func (m *RoaminghostModel) Flatten(ctx context.Context, from *dhcp.Roaminghost, 
 	}
 	m.PreferredLifetime = flex.FlattenInt64Pointer(from.PreferredLifetime)
 	m.PxeLeaseTime = flex.FlattenInt64Pointer(from.PxeLeaseTime)
-	if m.Template.IsUnknown() || m.Template.IsNull() {
-		m.Template = flex.FlattenStringPointer(from.Template)
-	}
-	if m.Ipv6Template.IsUnknown() || m.Ipv6Template.IsNull() {
-		m.Ipv6Template = flex.FlattenStringPointer(from.Ipv6Template)
-	}
+	m.Template = flex.FlattenStringPointer(from.Template)
+	m.Ipv6Template = flex.FlattenStringPointer(from.Ipv6Template)
 	m.UseBootfile = types.BoolPointerValue(from.UseBootfile)
 	m.UseBootserver = types.BoolPointerValue(from.UseBootserver)
 	m.UseDdnsDomainname = types.BoolPointerValue(from.UseDdnsDomainname)

--- a/internal/service/dhcp/range_resource_test.go
+++ b/internal/service/dhcp/range_resource_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/infobloxopen/terraform-provider-nios/internal/utils"
 )
 
-// TODO: Pending Tests
-// SPLIT MEMBER
-// SPLIT SCOPE
-
 // TODO: grid setup to run test cases
 // Cisco ISE settings
 // failover association:  "failover_association_1",  "failover_association"
@@ -2188,29 +2184,6 @@ func TestAccRangeResource_SubscribeSettings(t *testing.T) {
 	})
 }
 
-func TestAccRangeResource_Template(t *testing.T) {
-	resourceName := "nios_dhcp_range.test_template"
-	var v dhcp.Range
-	startAddr := "10.10.50.61"
-	endAddr := "10.10.50.70"
-	templateName := acctest.RandomNameWithPrefix("range-template")
-
-	// Template is an immutable field, hence no update step is added.
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRangeTemplate(startAddr, endAddr, templateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "template", templateName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccRangeResource_UnknownClients(t *testing.T) {
 	var resourceName = "nios_dhcp_range.test_unknown_clients"
 	var v dhcp.Range
@@ -4106,74 +4079,4 @@ resource "nios_dhcp_range" "test_use_update_dns_on_lease_renewal" {
     use_update_dns_on_lease_renewal = %t
 }
 `, startAddr, endAddr, useUpdateDnsOnLeaseRenewal)
-}
-
-func TestAccRangeResource_RestartIfNeeded(t *testing.T) {
-	resourceName := "nios_dhcp_range.test_restart_if_needed"
-	var v dhcp.Range
-	startAddr := "10.10.0.11"
-	endAddr := "10.10.0.12"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read
-			{
-				Config: testAccRangeRestartIfNeeded(startAddr, endAddr, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "true"),
-				),
-			},
-			// Update and Read
-			{
-				Config: testAccRangeRestartIfNeeded(startAddr, endAddr, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRangeExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "restart_if_needed", "false"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func testAccRangeRestartIfNeeded(startAddr, endAddr string, restartIfNeeded bool) string {
-	return fmt.Sprintf(`
-resource "nios_ipam_network" "test_restart_if_needed" {
-	network = "10.10.0.0/24"
-	network_view = "default"
-}
-
-resource "nios_dhcp_range" "test_restart_if_needed" {
-	start_addr = %q
-	end_addr = %q
-	restart_if_needed = %t
-	depends_on = [nios_ipam_network.test_restart_if_needed]
-}
-`, startAddr, endAddr, restartIfNeeded)
-}
-
-func testAccRangeTemplate(startAddr, endAddr, templateName string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_range_template" "test_template" {
-	name                = %q
-	number_of_addresses = 10
-	offset              = 1
-	cloud_api_compatible = true
-}
-
-resource "nios_ipam_network" "test_template" {
-	network = "10.10.50.0/24"
-	network_view = "default"
-}
-
-resource "nios_dhcp_range" "test_template" {
-	start_addr = %q
-	end_addr = %q
-	template = nios_dhcp_range_template.test_template.name
-	depends_on = [nios_ipam_network.test_template]
-}
-`, templateName, startAddr, endAddr)
 }

--- a/internal/service/dhcp/roaminghost_resource_test.go
+++ b/internal/service/dhcp/roaminghost_resource_test.go
@@ -967,28 +967,6 @@ func TestAccRoaminghostResource_Ipv6Options(t *testing.T) {
 	})
 }
 
-func TestAccRoaminghostResource_Ipv6Template(t *testing.T) {
-	resourceName := "nios_dhcp_roaminghost.test_ipv6_template"
-	var v dhcp.Roaminghost
-	name := acctest.RandomNameWithPrefix("roaminghost")
-	ipv6TemplateName := acctest.RandomNameWithPrefix("ipv6-fa-template")
-
-	// Ipv6Template is an immutable field, hence no update step is added.
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoaminghostIpv6Template(name, ipv6TemplateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoaminghostExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_template", ipv6TemplateName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccRoaminghostResource_Mac(t *testing.T) {
 	var resourceName = "nios_dhcp_roaminghost.test_mac"
 	var v dhcp.Roaminghost
@@ -1249,29 +1227,6 @@ func TestAccRoaminghostResource_PxeLeaseTime(t *testing.T) {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
-		},
-	})
-}
-
-func TestAccRoaminghostResource_Template(t *testing.T) {
-	resourceName := "nios_dhcp_roaminghost.test_template"
-	var v dhcp.Roaminghost
-	name := acctest.RandomNameWithPrefix("roaminghost")
-	mac := acctest.RandomMACAddress()
-	templateName := acctest.RandomNameWithPrefix("fa-template")
-
-	// Template is an immutable field, hence no update step is added.
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoaminghostTemplate(name, mac, templateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoaminghostExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "template", templateName),
-				),
-			},
 		},
 	})
 }
@@ -2235,22 +2190,6 @@ resource "nios_dhcp_roaminghost" "test_ipv6_options" {
 `, name, mac, addressType, matchClient, ipv6OptionsStr)
 }
 
-func testAccRoaminghostIpv6Template(name, ipv6TemplateName string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_ipv6fixedaddresstemplate" "test_ipv6_template" {
-	name = %q
-}
-
-resource "nios_dhcp_roaminghost" "test_ipv6_template" {
-	name = %q
-	address_type = "IPV6"
-	ipv6_match_option = "DUID"
-	ipv6_duid = "03:03:01:01:00:90:7f:97:ad:95"
-	ipv6_template = nios_dhcp_ipv6fixedaddresstemplate.test_ipv6_template.name
-}
-`, ipv6TemplateName, name)
-}
-
 func testAccRoaminghostMac(name string, mac string, addressType string, matchClient string) string {
 	return fmt.Sprintf(`
 resource "nios_dhcp_roaminghost" "test_mac" {
@@ -2358,22 +2297,6 @@ resource "nios_dhcp_roaminghost" "test_pxe_lease_time" {
     use_pxe_lease_time = true
 }
 `, name, mac, addressType, matchClient, pxeLeaseTime)
-}
-
-func testAccRoaminghostTemplate(name, mac, templateName string) string {
-	return fmt.Sprintf(`
-resource "nios_dhcp_fixedaddresstemplate" "test_template" {
-	name = %q
-}
-
-resource "nios_dhcp_roaminghost" "test_template" {
-	name = %q
-	mac = %q
-	address_type = "IPV4"
-	match_client = "MAC_ADDRESS"
-	template = nios_dhcp_fixedaddresstemplate.test_template.name
-}
-`, templateName, name, mac)
 }
 
 func testAccRoaminghostUseBootfile(name string, mac string, addressType string, matchClient string, useBootfile string) string {

--- a/internal/service/dhcp/sharednetwork_resource_test.go
+++ b/internal/service/dhcp/sharednetwork_resource_test.go
@@ -843,29 +843,6 @@ func TestAccSharednetworkResource_Networks(t *testing.T) {
 	})
 }
 
-func TestAccSharednetworkResource_NetworkView(t *testing.T) {
-	resourceName := "nios_dhcp_shared_network.test_network_view"
-	var v dhcp.Sharednetwork
-	name := acctest.RandomNameWithPrefix("shared_network")
-	networkView := acctest.RandomNameWithPrefix("network-view")
-	networks := []string{"${nios_ipam_network.test_network1.ref}", "${nios_ipam_network.test_network2.ref}"}
-
-	// Network_view is an immutable field, hence no update step is added.
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSharednetworkNetworkView(name, networkView, networks),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSharednetworkExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "network_view", networkView),
-				),
-			},
-		},
-	})
-}
-
 func TestAccSharednetworkResource_Nextserver(t *testing.T) {
 	var resourceName = "nios_dhcp_shared_network.test_nextserver"
 	var v dhcp.Sharednetwork
@@ -2056,32 +2033,6 @@ resource "nios_dhcp_shared_network" "test_networks" {
 	network3and4Replace2 := strings.Replace(network3and4Replace1, "test_network2", "test_network4", 1)
 	return strings.Join([]string{testAccBaseWithNetworks(
 		"201.45.0.0/24", "201.46.0.0/24"), network3and4Replace2, config}, "\n")
-}
-
-func testAccSharednetworkNetworkView(name, networkView string, networks []string) string {
-	networksStr := formatNetworksToHCL(networks)
-	config := fmt.Sprintf(`
-resource "nios_ipam_network_view" "test_network_view" {
-	name = %q
-}
-
-resource "nios_ipam_network" "test_network1" {
-	network      = "202.101.0.0/24"
-	network_view = nios_ipam_network_view.test_network_view.name
-}
-
-resource "nios_ipam_network" "test_network2" {
-	network      = "202.102.0.0/24"
-	network_view = nios_ipam_network_view.test_network_view.name
-}
-
-resource "nios_dhcp_shared_network" "test_network_view" {
-	name = %q
-	network_view = nios_ipam_network_view.test_network_view.name
-	networks = %s
-}
-`, networkView, name, networksStr)
-	return config
 }
 
 func testAccSharednetworkNextserver(name string, networks []string, nextserver string, useNextserver bool) string {


### PR DESCRIPTION
Reverts infobloxopen/terraform-provider-nios#539