### PR TITLE
[NPA-1955][FIX] - Marked the is_Default field as optional + computed in zone_association for few network objects 

### DIFF
--- a/internal/service/ipam/model_ipv6network_zone_associations.go
+++ b/internal/service/ipam/model_ipv6network_zone_associations.go
@@ -38,6 +38,7 @@ var Ipv6networkZoneAssociationsResourceSchemaAttributes = map[string]schema.Attr
 	},
 	"is_default": schema.BoolAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "True if this is the default zone.",
 	},
 	"view": schema.StringAttribute{

--- a/internal/service/ipam/model_ipv6networkcontainer_zone_associations.go
+++ b/internal/service/ipam/model_ipv6networkcontainer_zone_associations.go
@@ -38,6 +38,7 @@ var Ipv6networkcontainerZoneAssociationsResourceSchemaAttributes = map[string]sc
 	},
 	"is_default": schema.BoolAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "True if this is the default zone.",
 	},
 	"view": schema.StringAttribute{


### PR DESCRIPTION
Marked the is_Default field as optional + computed in zone_association for few network objects ( ipv6network and ipv6 network container )