### PR TITLE
Fix failing UTs for DXL Endpoint and Notification REST Endpoint

### DIFF
--- a/internal/service/misc/dxl_endpoint_resource_test.go
+++ b/internal/service/misc/dxl_endpoint_resource_test.go
@@ -605,11 +605,11 @@ func TestAccDxlEndpointResource_WapiUserPassword(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccDxlEndpointWapiUserPassword(clientCertificateFile, broker, name, "GM", "admin", "password456"),
+				Config: testAccDxlEndpointWapiUserPassword(clientCertificateFile, broker, name, "GM", "admin_updated", "password456"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDxlEndpointExists(context.Background(), resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "password_version", "2"),
-					resource.TestCheckResourceAttr(resourceName, "wapi_user_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "wapi_user_name", "admin_updated"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/service/notification/notification_rest_endpoint_resource_test.go
+++ b/internal/service/notification/notification_rest_endpoint_resource_test.go
@@ -224,7 +224,6 @@ func TestAccNotificationRestEndpointResource_ClientCertificateFile(t *testing.T)
 				Config: testAccNotificationRestEndpointClientCertificateFile(name, outboundMemberType, uri, clientCertificateFile),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotificationRestEndpointExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, "client_certificate_token"),
 				),
 			},
 			// Update and Read
@@ -232,7 +231,6 @@ func TestAccNotificationRestEndpointResource_ClientCertificateFile(t *testing.T)
 				Config: testAccNotificationRestEndpointClientCertificateFile(name, outboundMemberType, uri, updatedClientCertificateFile),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNotificationRestEndpointExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, "client_certificate_token"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
## Summary
Fixes two failing acceptance tests on `main`: the DXL Endpoint update-step test wasn't actually changing the `wapi_user_name` value it claimed to update, and the Notification REST Endpoint test asserted on `client_certificate_token` being set when that attribute isn't set by the backend.

## Type of Change
- [x] 🐛 Bug Fix

## Affected Packages
- [x] `misc` (`dxl_endpoint`)
- [x] `notification` (`notification_rest_endpoint`)

**Resource / Data Source**: `nios_misc_dxl_endpoint`, `nios_notification_rest_endpoint`
**Description**: Fixed test assertions so the update step exercises an actual value change; removed unreliable `client_certificate_token` assertions.

## Schema Changes
_None_

## Testing
- [x] Acceptance tests added / updated

## Additional Context
Test-only changes; no code was modified.